### PR TITLE
Maven integration

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,8 +31,15 @@ jobs:
       - name: Execute Go tests
         working-directory: ./gremlin-go
         run: |
-          docker-compose up --exit-code-from integration-tests integration-tests
+          docker-compose up --exit-code-from gremlin-go-integration-tests gremlin-go-integration-tests
           docker-compose down
+
+      # TODO AN 1045: Add test execution for godog. May not fully enable though because some will likely fail.
+      # - name: Execute Go tests
+      #   working-directory: ./gremlin-go
+      #   run: |
+      #     docker-compose up --exit-code-from gremlin-godog-tests gremlin-go-godog-tests
+      #     docker-compose down
 
       - name: Go-Vet
         working-directory: ./gremlin-go

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,7 +38,7 @@ jobs:
       # - name: Execute Go tests
       #   working-directory: ./gremlin-go
       #   run: |
-      #     docker-compose up --exit-code-from gremlin-godog-tests gremlin-go-godog-tests
+      #     docker-compose up --exit-code-from gremlin-go-godog-tests gremlin-go-godog-tests
       #     docker-compose down
 
       - name: Go-Vet

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ BenchmarkDotNet.Artifacts/
 /Dockerfile
 docs/gremlint/
 gremlint/
+coverage.out

--- a/gremlin-go/docker-compose.yml
+++ b/gremlin-go/docker-compose.yml
@@ -22,8 +22,8 @@ services:
     image: tinkerpop/gremlin-server
     ports:
       - "8182:8182"
-  integration-tests:
-    container_name: integration-tests
+  gremlin-go-integration-tests:
+    container_name: gremlin-go-integration-tests
     image: golang:1.17
     volumes:
       - .:/go_app
@@ -33,7 +33,23 @@ services:
       - RUN_INTEGRATION_TESTS=true
     working_dir: /go_app
     command: >
-        bash -c "go install github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
-        && go test -v -json ./... -race -covermode=atomic -coverprofile=\"coverage.out\" | gotestfmt"
+      bash -c "go install github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
+      && go test -v -json ./... -race -covermode=atomic -coverprofile=\"coverage.out\" | gotestfmt"
+    depends_on:
+      - gremlin-server
+  # TODO
+  gremlin-go-godog-tests:
+    container_name: gremlin-go-godog-tests
+    image: golang:1.17
+    volumes:
+      - .:/go_app
+    environment:
+      - GREMLIN_SERVER_HOSTNAME=gremlin-server
+      - GREMLIN_SERVER_PORT=8182
+      - RUN_INTEGRATION_TESTS=true
+    working_dir: /go_app
+    command: >
+      bash -c "go install github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
+      && go test -v -json ./... -race -covermode=atomic -coverprofile=\"coverage.out\" | gotestfmt"
     depends_on:
       - gremlin-server

--- a/gremlin-go/pom.xml
+++ b/gremlin-go/pom.xml
@@ -1,0 +1,148 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.tinkerpop</groupId>
+        <artifactId>tinkerpop</artifactId>
+        <version>3.5.3-SNAPSHOT</version>
+    </parent>
+    <artifactId>gremlin-go</artifactId>
+    <name>Apache TinkerPop :: Gremlin Go</name>
+    <properties>
+        <!-- provides a way to convert maven.test.skip value to skipTests for use in skipping go tests -->
+        <maven.test.skip>false</maven.test.skip>
+        <skipTests>${maven.test.skip}</skipTests>
+        <TEST_TRANSACTIONS>false</TEST_TRANSACTIONS>
+        <gremlin.server.dir>${project.parent.basedir}/gremlin-server</gremlin.server.dir>
+    </properties>
+    <build>
+    </build>
+
+    <profiles>
+        <!-- Activates the testing of Go Docker -->
+        <profile>
+            <id>glv-go</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <file>
+                    <exists>.glv</exists>
+                </file>
+            </activation>
+            <build>
+                <directory>${basedir}/target</directory>
+                <finalName>${project.artifactId}-${project.version}</finalName>
+                <plugins>
+                    <plugin>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <version>1.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>Run Integration tests</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>docker-compose</executable>
+                                    <arguments>
+                                        <argument>up</argument>
+                                        <argument>--exit-code-from</argument>
+                                        <argument>gremlin-go-integration-tests</argument>
+                                        <argument>gremlin-go-integration-tests</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>Run Godog tests</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <!--
+                                        Plugin to execute Godog tests.
+                                        TODO AN-1045: Verify this lifecycle works properly.
+                                    -->
+                                    <executable>docker-compose</executable>
+                                    <arguments>
+                                        <argument>up</argument>
+                                        <argument>--exit-code-from</argument>
+                                        <argument>gremlin-go-godog-tests</argument>
+                                        <argument>gremlin-go-godog-tests</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>Shutdown container</id>
+                                <phase>verify</phase>
+                                <configuration>
+                                    <executable>docker-compose</executable>
+                                    <arguments>
+                                        <argument>down</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!--
+                        TODO AN-1045: Plugin to generate Cucumber Godog tests.
+                        Verify this lifecycle works properly.
+                    -->
+                    <plugin>
+                        <groupId>org.codehaus.gmavenplus</groupId>
+                        <artifactId>gmavenplus-plugin</artifactId>
+                        <dependencies>
+                        <!--
+                            TODO AN-1045: Plugin to generate Cucumber Godog tests.
+                            Make sure appropriate dependencies are included.
+                        -->
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>generate-radish-support</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>execute</goal>
+                                </goals>
+                                <configuration>
+                                    <properties>
+                                        <property>
+                                            <name>projectBaseDir</name>
+                                            <value>${project.basedir}/../</value>
+                                        </property>
+                                    </properties>
+                                    <scripts>
+                                    <!--
+                                     TODO AN-1045: Plugin to generate Cucumber Godog tests.
+                                     Enable groovy script.
+                                        <script>${project.basedir}/build/generate.groovy</script>
+                                    -->
+                                    </scripts>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,7 @@ limitations under the License.
         <module>gremlin-archetype</module>
         <module>gremlin-tools</module>
         <module>gremlint</module>
+        <module>gremlin-go</module>
     </modules>
     <scm>
         <connection>scm:git:git@github.com:apache/tinkerpop.git</connection>
@@ -442,6 +443,7 @@ limitations under the License.
                         <exclude>**/venv/**</exclude>
                         <exclude>**/docfx/**</exclude>
                         <exclude>**/go.sum</exclude>
+                        <exclude>**/coverage.out</exclude>
                     </excludes>
                     <licenses>
                         <license implementation="org.apache.rat.analysis.license.ApacheSoftwareLicense20"/>


### PR DESCRIPTION
*Issue #, if available:*
AN-974 TinkerPop build Integration via Maven

*Description of changes:*
- Added maven lifecycle to invoke docker and test golang
- Added hooks for Godog in maven
- Updated docker-compose

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
