### PR TITLE
AN-1063 do not run loadEmptyDataGraph for each test

### DIFF
--- a/gremlin-go/cucumber/featureSteps_test.go
+++ b/gremlin-go/cucumber/featureSteps_test.go
@@ -713,7 +713,6 @@ func InitializeTestSuite(ctx *godog.TestSuiteContext) {
 func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Before(func(ctx context.Context, sc *godog.Scenario) (context.Context, error) {
 		tg.scenario = sc
-		tg.loadEmptyDataGraph()
 		// Add tg.recreateAllDataGraphConnection() here and tg.closeAllDataGraphConnection() in an After scenario
 		// hook if necessary to isolate failing tests that closes the shared connection.
 		return ctx, nil

--- a/gremlin-go/cucumber/tinkerPopWorld.go
+++ b/gremlin-go/cucumber/tinkerPopWorld.go
@@ -115,6 +115,10 @@ func (t *TinkerPopWorld) loadAllDataGraph() {
 }
 
 func (t *TinkerPopWorld) loadEmptyDataGraph() {
+	if _, ok := t.graphDataMap["empty"]; ok {
+		return
+	}
+
 	connection, _ := gremlingo.NewDriverRemoteConnection(scenarioUrl(), func(settings *gremlingo.DriverRemoteConnectionSettings) {
 		settings.TraversalSource = "ggraph"
 	})

--- a/gremlin-go/cucumber/tinkerPopWorld.go
+++ b/gremlin-go/cucumber/tinkerPopWorld.go
@@ -115,10 +115,6 @@ func (t *TinkerPopWorld) loadAllDataGraph() {
 }
 
 func (t *TinkerPopWorld) loadEmptyDataGraph() {
-	if _, ok := t.graphDataMap["empty"]; ok {
-		return
-	}
-
 	connection, _ := gremlingo.NewDriverRemoteConnection(scenarioUrl(), func(settings *gremlingo.DriverRemoteConnectionSettings) {
 		settings.TraversalSource = "ggraph"
 	})


### PR DESCRIPTION
*Issue #, if available:*
https://bitquill.atlassian.net/browse/AN-1063

*Description of changes:*
Investigate Gorilla transport layer issues

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
