### PR TITLE
Session spawnable only from driverRemoteConnections and Session mirrors Parent DRC settings

### DIFF
--- a/gremlin-go/driver/client.go
+++ b/gremlin-go/driver/client.go
@@ -47,7 +47,7 @@ type ClientSettings struct {
 	NewConnectionThreshold int
 	// Maximum number of concurrent connections. Default: number of runtime processors
 	MaximumConcurrentConnections int
-	Session                      string
+	session                      string
 }
 
 // Client is used to connect and interact with a Gremlin-supported server.
@@ -84,7 +84,7 @@ func NewClient(url string, configurations ...func(settings *ClientSettings)) (*C
 
 		NewConnectionThreshold:       defaultNewConnectionThreshold,
 		MaximumConcurrentConnections: runtime.NumCPU(),
-		Session:                      "",
+		session:                      "",
 	}
 	for _, configuration := range configurations {
 		configuration(settings)
@@ -102,7 +102,7 @@ func NewClient(url string, configurations ...func(settings *ClientSettings)) (*C
 	}
 
 	logHandler := newLogHandler(settings.Logger, settings.LogVerbosity, settings.Language)
-	if settings.Session != "" {
+	if settings.session != "" {
 		logHandler.log(Debug, sessionDetected)
 		settings.MaximumConcurrentConnections = 1
 	}
@@ -119,7 +119,7 @@ func NewClient(url string, configurations ...func(settings *ClientSettings)) (*C
 		logHandler:      logHandler,
 		transporterType: settings.TransporterType,
 		connections:     pool,
-		session:         settings.Session,
+		session:         settings.session,
 	}
 
 	return client, nil
@@ -128,7 +128,7 @@ func NewClient(url string, configurations ...func(settings *ClientSettings)) (*C
 // Close closes the client via connection.
 // This is idempotent due to the underlying close() methods being idempotent as well.
 func (client *Client) Close() {
-	// If it is a Session, call closeSession
+	// If it is a session, call closeSession
 	if client.session != "" {
 		err := client.closeSession()
 		if err != nil {

--- a/gremlin-go/driver/client.go
+++ b/gremlin-go/driver/client.go
@@ -47,7 +47,6 @@ type ClientSettings struct {
 	NewConnectionThreshold int
 	// Maximum number of concurrent connections. Default: number of runtime processors
 	MaximumConcurrentConnections int
-	session                      string
 }
 
 // Client is used to connect and interact with a Gremlin-supported server.
@@ -84,7 +83,6 @@ func NewClient(url string, configurations ...func(settings *ClientSettings)) (*C
 
 		NewConnectionThreshold:       defaultNewConnectionThreshold,
 		MaximumConcurrentConnections: runtime.NumCPU(),
-		session:                      "",
 	}
 	for _, configuration := range configurations {
 		configuration(settings)
@@ -102,10 +100,6 @@ func NewClient(url string, configurations ...func(settings *ClientSettings)) (*C
 	}
 
 	logHandler := newLogHandler(settings.Logger, settings.LogVerbosity, settings.Language)
-	if settings.session != "" {
-		logHandler.log(Debug, sessionDetected)
-		settings.MaximumConcurrentConnections = 1
-	}
 
 	pool, err := newLoadBalancingPool(url, logHandler, connSettings, settings.NewConnectionThreshold, settings.MaximumConcurrentConnections)
 	if err != nil {
@@ -119,7 +113,7 @@ func NewClient(url string, configurations ...func(settings *ClientSettings)) (*C
 		logHandler:      logHandler,
 		transporterType: settings.TransporterType,
 		connections:     pool,
-		session:         settings.session,
+		session:         "",
 	}
 
 	return client, nil

--- a/gremlin-go/driver/connection_test.go
+++ b/gremlin-go/driver/connection_test.go
@@ -615,8 +615,8 @@ func TestConnection(t *testing.T) {
 			func(settings *ClientSettings) {
 				settings.TlsConfig = testNoAuthTlsConfig
 				settings.AuthInfo = testNoAuthAuthInfo
-				settings.session = "abc123"
 			})
+		client.session = "abc123"
 		assert.Nil(t, err)
 		assert.NotNil(t, client)
 		defer client.Close()

--- a/gremlin-go/driver/connection_test.go
+++ b/gremlin-go/driver/connection_test.go
@@ -608,14 +608,14 @@ func TestConnection(t *testing.T) {
 		assert.NotNil(t, result)
 	})
 
-	t.Run("Test client.submit() on Session", func(t *testing.T) {
+	t.Run("Test client.submit() on session", func(t *testing.T) {
 		skipTestsIfNotEnabled(t, integrationTestSuiteName, testNoAuthEnable)
 
 		client, err := NewClient(testNoAuthUrl,
 			func(settings *ClientSettings) {
 				settings.TlsConfig = testNoAuthTlsConfig
 				settings.AuthInfo = testNoAuthAuthInfo
-				settings.Session = "abc123"
+				settings.session = "abc123"
 			})
 		assert.Nil(t, err)
 		assert.NotNil(t, client)
@@ -865,7 +865,7 @@ func TestConnection(t *testing.T) {
 			assert.Equal(t, 2, len(remote.spawnedSessions))
 		})
 
-		t.Run("Test Session close", func(t *testing.T) {
+		t.Run("Test session close", func(t *testing.T) {
 			skipTestsIfNotEnabled(t, integrationTestSuiteName, testNoAuthEnable)
 			remote, err := NewDriverRemoteConnection(testNoAuthWithAliasUrl,
 				func(settings *DriverRemoteConnectionSettings) {
@@ -888,7 +888,7 @@ func TestConnection(t *testing.T) {
 			assert.Equal(t, 3, len(remote.spawnedSessions))
 		})
 
-		t.Run("Test Session failures", func(t *testing.T) {
+		t.Run("Test session failures", func(t *testing.T) {
 			skipTestsIfNotEnabled(t, integrationTestSuiteName, testNoAuthEnable)
 			remote, err := NewDriverRemoteConnection(testNoAuthWithAliasUrl,
 				func(settings *DriverRemoteConnectionSettings) {

--- a/gremlin-go/driver/driverRemoteConnection.go
+++ b/gremlin-go/driver/driverRemoteConnection.go
@@ -189,7 +189,6 @@ func (driver *DriverRemoteConnection) CreateSession(sessionId ...string) (*Drive
 		settings.TraversalSource = driver.client.traversalSource
 		settings.TransporterType = driver.client.transporterType
 
-		// Should we keep the same logger as parent DRC? Language isnt stored in DRC, default to English?
 		settings.Logger = driver.client.logHandler.logger
 		settings.LogVerbosity = driver.client.logHandler.verbosity
 		//settings.Language = driver.client.logHandler

--- a/gremlin-go/driver/driverRemoteConnection.go
+++ b/gremlin-go/driver/driverRemoteConnection.go
@@ -69,6 +69,8 @@ func NewDriverRemoteConnection(
 	url string,
 	configurations ...func(settings *DriverRemoteConnectionSettings)) (*DriverRemoteConnection, error) {
 	settings := &DriverRemoteConnectionSettings{
+		session:           "",
+		
 		TraversalSource:   "g",
 		TransporterType:   Gorilla,
 		LogVerbosity:      Info,
@@ -88,7 +90,6 @@ func NewDriverRemoteConnection(
 
 		NewConnectionThreshold:       defaultNewConnectionThreshold,
 		MaximumConcurrentConnections: runtime.NumCPU(),
-		session:                      "",
 		InitialConcurrentConnections: defaultInitialConcurrentConnections,
 	}
 	for _, configuration := range configurations {

--- a/gremlin-go/driver/driverRemoteConnection.go
+++ b/gremlin-go/driver/driverRemoteConnection.go
@@ -47,7 +47,7 @@ type DriverRemoteConnectionSettings struct {
 	NewConnectionThreshold int
 	// Maximum number of concurrent connections. Default: number of runtime processors
 	MaximumConcurrentConnections int
-	Session                      string
+	session                      string
 }
 
 // DriverRemoteConnection is a remote connection.
@@ -84,7 +84,7 @@ func NewDriverRemoteConnection(
 		WriteBufferSize: 0,
 
 		MaximumConcurrentConnections: runtime.NumCPU(),
-		Session:                      "",
+		session:                      "",
 	}
 	for _, configuration := range configurations {
 		configuration(settings)
@@ -102,7 +102,7 @@ func NewDriverRemoteConnection(
 	}
 
 	logHandler := newLogHandler(settings.Logger, settings.LogVerbosity, settings.Language)
-	if settings.Session != "" {
+	if settings.session != "" {
 		logHandler.log(Debug, sessionDetected)
 		settings.MaximumConcurrentConnections = 1
 	}
@@ -121,7 +121,7 @@ func NewDriverRemoteConnection(
 		logHandler:      logHandler,
 		transporterType: settings.TransporterType,
 		connections:     pool,
-		session:         settings.Session,
+		session:         settings.session,
 	}
 
 	return &DriverRemoteConnection{client: client, isClosed: false}, nil
@@ -169,7 +169,7 @@ func (driver *DriverRemoteConnection) isSession() bool {
 	return driver.client.session != ""
 }
 
-// CreateSession generates a new Session. sessionId stores the optional UUID param. It can be used to create a Session with a specific UUID.
+// CreateSession generates a new session. sessionId stores the optional UUID param. It can be used to create a session with a specific UUID.
 func (driver *DriverRemoteConnection) CreateSession(sessionId ...string) (*DriverRemoteConnection, error) {
 	if len(sessionId) > 1 {
 		return nil, newError(err0201CreateSessionMultipleIdsError)
@@ -181,9 +181,9 @@ func (driver *DriverRemoteConnection) CreateSession(sessionId ...string) (*Drive
 	drc, err := NewDriverRemoteConnection(driver.client.url, func(settings *DriverRemoteConnectionSettings) {
 		settings.TraversalSource = driver.client.traversalSource
 		if len(sessionId) == 1 {
-			settings.Session = sessionId[0]
+			settings.session = sessionId[0]
 		} else {
-			settings.Session = uuid.New().String()
+			settings.session = uuid.New().String()
 		}
 	})
 	if err != nil {

--- a/gremlin-go/driver/driverRemoteConnection.go
+++ b/gremlin-go/driver/driverRemoteConnection.go
@@ -185,6 +185,25 @@ func (driver *DriverRemoteConnection) CreateSession(sessionId ...string) (*Drive
 		} else {
 			settings.session = uuid.New().String()
 		}
+
+		settings.TraversalSource = driver.client.traversalSource
+		settings.TransporterType = driver.client.transporterType
+
+		// Should we keep the same logger as parent DRC? Language isnt stored in DRC, default to English?
+		settings.Logger = driver.client.logHandler.logger
+		settings.LogVerbosity = driver.client.logHandler.verbosity
+		//settings.Language = driver.client.logHandler
+
+		settings.AuthInfo = driver.client.connections.(*loadBalancingPool).connSettings.authInfo
+		settings.TlsConfig = driver.client.connections.(*loadBalancingPool).connSettings.tlsConfig
+		settings.KeepAliveInterval = driver.client.connections.(*loadBalancingPool).connSettings.keepAliveInterval
+		settings.WriteDeadline = driver.client.connections.(*loadBalancingPool).connSettings.writeDeadline
+		settings.ConnectionTimeout = driver.client.connections.(*loadBalancingPool).connSettings.connectionTimeout
+		settings.NewConnectionThreshold = driver.client.connections.(*loadBalancingPool).newConnectionThreshold
+		settings.EnableCompression = driver.client.connections.(*loadBalancingPool).connSettings.enableCompression
+		settings.ReadBufferSize = driver.client.connections.(*loadBalancingPool).connSettings.readBufferSize
+		settings.WriteBufferSize = driver.client.connections.(*loadBalancingPool).connSettings.writeBufferSize
+		settings.MaximumConcurrentConnections = cap(driver.client.connections.(*loadBalancingPool).connections)
 	})
 	if err != nil {
 		return nil, err

--- a/gremlin-go/driver/driverRemoteConnection.go
+++ b/gremlin-go/driver/driverRemoteConnection.go
@@ -29,6 +29,8 @@ import (
 
 // DriverRemoteConnectionSettings are used to configure the DriverRemoteConnection.
 type DriverRemoteConnectionSettings struct {
+	session string
+	
 	TraversalSource   string
 	TransporterType   TransporterType
 	LogVerbosity      LogVerbosity
@@ -49,8 +51,6 @@ type DriverRemoteConnectionSettings struct {
 	MaximumConcurrentConnections int
 	// Initial amount of instantiated connections. Default: 1
 	InitialConcurrentConnections int
-	
-	session                      string
 }
 
 // DriverRemoteConnection is a remote connection.

--- a/gremlin-go/driver/driverRemoteConnection.go
+++ b/gremlin-go/driver/driverRemoteConnection.go
@@ -47,9 +47,10 @@ type DriverRemoteConnectionSettings struct {
 	NewConnectionThreshold int
 	// Maximum number of concurrent connections. Default: number of runtime processors
 	MaximumConcurrentConnections int
-	session                      string
 	// Initial amount of instantiated connections. Default: 1
 	InitialConcurrentConnections int
+	
+	session                      string
 }
 
 // DriverRemoteConnection is a remote connection.

--- a/gremlin-go/driver/driverRemoteConnection.go
+++ b/gremlin-go/driver/driverRemoteConnection.go
@@ -180,13 +180,27 @@ func (driver *DriverRemoteConnection) CreateSession(sessionId ...string) (*Drive
 
 	driver.client.logHandler.log(Info, creatingSessionConnection)
 	drc, err := NewDriverRemoteConnection(driver.client.url, func(settings *DriverRemoteConnectionSettings) {
-		parentSettings := *driver.settings
-		settings = &parentSettings
 		if len(sessionId) == 1 {
 			settings.session = sessionId[0]
 		} else {
 			settings.session = uuid.New().String()
 		}
+		// copy other settings from parent
+		settings.TraversalSource = driver.settings.TraversalSource
+		settings.TransporterType = driver.settings.TransporterType
+		settings.Logger = driver.settings.Logger
+		settings.LogVerbosity = driver.settings.LogVerbosity
+		settings.Language = driver.settings.Language
+		settings.AuthInfo = driver.settings.AuthInfo
+		settings.TlsConfig = driver.settings.TlsConfig
+		settings.KeepAliveInterval = driver.settings.KeepAliveInterval
+		settings.WriteDeadline = driver.settings.WriteDeadline
+		settings.ConnectionTimeout = driver.settings.ConnectionTimeout
+		settings.NewConnectionThreshold = driver.settings.NewConnectionThreshold
+		settings.EnableCompression = driver.settings.EnableCompression
+		settings.ReadBufferSize = driver.settings.ReadBufferSize
+		settings.WriteBufferSize = driver.settings.WriteBufferSize
+		settings.MaximumConcurrentConnections = driver.settings.MaximumConcurrentConnections
 	})
 	if err != nil {
 		return nil, err

--- a/gremlin-go/driver/serializer.go
+++ b/gremlin-go/driver/serializer.go
@@ -50,7 +50,6 @@ func newGraphBinarySerializer(handler *logHandler) serializer {
 const versionByte byte = 0x81
 
 func convertArgs(request *request, gs graphBinarySerializer) (map[string]interface{}, error) {
-	// TODO: Remote transaction session processor is same as bytecode
 	if request.op != bytecodeProcessor {
 		return request.args, nil
 	}


### PR DESCRIPTION
*Issue #, if available:*
https://bitquill.atlassian.net/jira/software/c/projects/AN/boards/36?modal=detail&selectedIssue=AN-1120

*Description of changes:*
Session spawnable only from driverRemoteConnections

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
