### PR TITLE
Gremlin Javascript, Gremlint invalid Character Error fixes for Windows Build

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,114 +14,114 @@ jobs:
           distribution: 'temurin'
       - name: Build with Maven
         run: mvn clean install -DskipTests -Dci --batch-mode -D"org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener"="warn"
-#  java-jdk11:
-#    name: mvn clean install - jdk11
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'adopt'
-#      - name: Build with Maven
-#        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-#  java-jdk8:
-#    name: mvn clean install - jdk8
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 8
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '8'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-#  gremlin-server-default:
-#    name: gremlin-server default
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j
-#  gremlin-server-unified:
-#    name: gremlin-server unified
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j -DtestUnified=true
-#  spark-core:
-#    name: spark core
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false '-Dit.test=*IntegrateTest,!SparkGryoSerializerGraphComputerProcessIntegrateTest'
-#  spark-gryo:
-#    name: spark gryo
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false -Dit.test=SparkGryoSerializerGraphComputerProcessIntegrateTest
-#  gremlin-console:
-#    name: gremlin-console
-#    timeout-minutes: 20
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :gremlin-console -DskipTests -DskipIntegrationTests=false
+  java-jdk11:
+    name: mvn clean install - jdk11
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Build with Maven
+        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  java-jdk8:
+    name: mvn clean install - jdk8
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  gremlin-server-default:
+    name: gremlin-server default
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j
+  gremlin-server-unified:
+    name: gremlin-server unified
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j -DtestUnified=true
+  spark-core:
+    name: spark core
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false '-Dit.test=*IntegrateTest,!SparkGryoSerializerGraphComputerProcessIntegrateTest'
+  spark-gryo:
+    name: spark gryo
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false -Dit.test=SparkGryoSerializerGraphComputerProcessIntegrateTest
+  gremlin-console:
+    name: gremlin-console
+    timeout-minutes: 20
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :gremlin-console -DskipTests -DskipIntegrationTests=false
   javascript:
     name: javascript
     timeout-minutes: 15
@@ -167,74 +167,74 @@ jobs:
           touch gremlin-python/.glv
           mvn clean install -pl -:gremlin-javascript,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
           mvn verify -pl gremlin-python -DincludeNeo4j
-#  dotnet:
-#    name: .NET
-#    timeout-minutes: 20
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Set up .NET 6.0.x
-#        uses: actions/setup-dotnet@v2
-#        with:
-#          dotnet-version: '6.0.x'
-#      - name: Build with Maven
-#        run: |
-#          touch gremlin-dotnet/src/.glv
-#          touch gremlin-dotnet/test/.glv
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :gremlin-dotnet,:gremlin-dotnet-tests -P gremlin-dotnet -DincludeNeo4j
-#  neo4j-gremlin:
-#    name: neo4j-gremlin
-#    timeout-minutes: 20
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
-#          mvn verify -pl :neo4j-gremlin -DincludeNeo4j
-#  go:
-#    name: go
-#    timeout-minutes: 20
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v3
-#
-#      - name: Setup Go
-#        uses: actions/setup-go@v3
-#        with:
-#          go-version: '1.17'
-#
-#      - name: Generate Gremlin Server Base Image
-#        working-directory: .
-#        run: |
-#          mvn clean install -pl :gremlin-server -DskipTests -DskipIntegrationTests=true -am && mvn install -Pdocker-images -pl :gremlin-server
-#
-#      - name: Execute Go tests
-#        working-directory: ./gremlin-go
-#        run: |
-#          docker-compose up --exit-code-from gremlin-go-integration-tests
-#          docker-compose down
-#
-#      - name: Upload to Codecov
-#        uses: codecov/codecov-action@v2
-#        with:
-#          working-directory: ./gremlin-go
-#
-#      - name: Go-Vet
-#        working-directory: ./gremlin-go
-#        run: go vet ./...
+  dotnet:
+    name: .NET
+    timeout-minutes: 20
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Set up .NET 6.0.x
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '6.0.x'
+      - name: Build with Maven
+        run: |
+          touch gremlin-dotnet/src/.glv
+          touch gremlin-dotnet/test/.glv
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :gremlin-dotnet,:gremlin-dotnet-tests -P gremlin-dotnet -DincludeNeo4j
+  neo4j-gremlin:
+    name: neo4j-gremlin
+    timeout-minutes: 20
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
+          mvn verify -pl :neo4j-gremlin -DincludeNeo4j
+  go:
+    name: go
+    timeout-minutes: 20
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.17'
+
+      - name: Generate Gremlin Server Base Image
+        working-directory: .
+        run: |
+          mvn clean install -pl :gremlin-server -DskipTests -DskipIntegrationTests=true -am && mvn install -Pdocker-images -pl :gremlin-server
+
+      - name: Execute Go tests
+        working-directory: ./gremlin-go
+        run: |
+          docker-compose up --exit-code-from gremlin-go-integration-tests
+          docker-compose down
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          working-directory: ./gremlin-go
+
+      - name: Go-Vet
+        working-directory: ./gremlin-go
+        run: go vet ./...

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,118 +14,118 @@ jobs:
           distribution: 'temurin'
       - name: Build with Maven
         run: mvn clean install -DskipTests -Dci --batch-mode -D"org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener"="warn"
-#  java-jdk11:
-#    name: mvn clean install - jdk11
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'adopt'
-#      - name: Build with Maven
-#        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-#  java-jdk8:
-#    name: mvn clean install - jdk8
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 8
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '8'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-#  gremlin-server-default:
-#    name: gremlin-server default
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j
-#  gremlin-server-unified:
-#    name: gremlin-server unified
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j -DtestUnified=true
-#  spark-core:
-#    name: spark core
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false '-Dit.test=*IntegrateTest,!SparkGryoSerializerGraphComputerProcessIntegrateTest'
-#  spark-gryo:
-#    name: spark gryo
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false -Dit.test=SparkGryoSerializerGraphComputerProcessIntegrateTest
-#  gremlin-console:
-#    name: gremlin-console
-#    timeout-minutes: 20
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :gremlin-console -DskipTests -DskipIntegrationTests=false
+  java-jdk11:
+    name: mvn clean install - jdk11
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Build with Maven
+        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  java-jdk8:
+    name: mvn clean install - jdk8
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  gremlin-server-default:
+    name: gremlin-server default
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j
+  gremlin-server-unified:
+    name: gremlin-server unified
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j -DtestUnified=true
+  spark-core:
+    name: spark core
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false '-Dit.test=*IntegrateTest,!SparkGryoSerializerGraphComputerProcessIntegrateTest'
+  spark-gryo:
+    name: spark gryo
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false -Dit.test=SparkGryoSerializerGraphComputerProcessIntegrateTest
+  gremlin-console:
+    name: gremlin-console
+    timeout-minutes: 20
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :gremlin-console -DskipTests -DskipIntegrationTests=false
   javascript:
     name: javascript
     timeout-minutes: 15
-#    needs: smoke
+    needs: smoke
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -141,100 +141,100 @@ jobs:
         run: |
           mvn clean install -pl -:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
           mvn verify -pl :gremlin-javascript,:gremlint -DincludeNeo4j
-#  python:
-#    name: python
-#    timeout-minutes: 20
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Set up Python 3.x
-#        uses: actions/setup-python@v3
-#        with:
-#          python-version: '3.8'
-#      - name: Setup Python requirements
-#        run: |
-#          sudo apt install gcc libkrb5-dev
-#          python3 -m pip install --upgrade pip
-#          pip install virtualenv
-#      - name: Build with Maven
-#        run: |
-#          touch gremlin-python/.glv
-#          mvn clean install -pl -:gremlin-javascript,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl gremlin-python -DincludeNeo4j
-#  dotnet:
-#    name: .NET
-#    timeout-minutes: 20
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Set up .NET 6.0.x
-#        uses: actions/setup-dotnet@v2
-#        with:
-#          dotnet-version: '6.0.x'
-#      - name: Build with Maven
-#        run: |
-#          touch gremlin-dotnet/src/.glv
-#          touch gremlin-dotnet/test/.glv
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :gremlin-dotnet,:gremlin-dotnet-tests -P gremlin-dotnet -DincludeNeo4j
-#  neo4j-gremlin:
-#    name: neo4j-gremlin
-#    timeout-minutes: 20
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
-#          mvn verify -pl :neo4j-gremlin -DincludeNeo4j
-#  go:
-#    name: go
-#    timeout-minutes: 20
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v3
-#
-#      - name: Setup Go
-#        uses: actions/setup-go@v3
-#        with:
-#          go-version: '1.17'
-#
-#      - name: Generate Gremlin Server Base Image
-#        working-directory: .
-#        run: |
-#          mvn clean install -pl :gremlin-server -DskipTests -DskipIntegrationTests=true -am && mvn install -Pdocker-images -pl :gremlin-server
-#
-#      - name: Execute Go tests
-#        working-directory: ./gremlin-go
-#        run: |
-#          docker-compose up --exit-code-from gremlin-go-integration-tests
-#          docker-compose down
-#
-#      - name: Upload to Codecov
-#        uses: codecov/codecov-action@v2
-#        with:
-#          working-directory: ./gremlin-go
-#
-#      - name: Go-Vet
-#        working-directory: ./gremlin-go
-#        run: go vet ./...
+  python:
+    name: python
+    timeout-minutes: 20
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+      - name: Setup Python requirements
+        run: |
+          sudo apt install gcc libkrb5-dev
+          python3 -m pip install --upgrade pip
+          pip install virtualenv
+      - name: Build with Maven
+        run: |
+          touch gremlin-python/.glv
+          mvn clean install -pl -:gremlin-javascript,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl gremlin-python -DincludeNeo4j
+  dotnet:
+    name: .NET
+    timeout-minutes: 20
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Set up .NET 6.0.x
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '6.0.x'
+      - name: Build with Maven
+        run: |
+          touch gremlin-dotnet/src/.glv
+          touch gremlin-dotnet/test/.glv
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :gremlin-dotnet,:gremlin-dotnet-tests -P gremlin-dotnet -DincludeNeo4j
+  neo4j-gremlin:
+    name: neo4j-gremlin
+    timeout-minutes: 20
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
+          mvn verify -pl :neo4j-gremlin -DincludeNeo4j
+  go:
+    name: go
+    timeout-minutes: 20
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.17'
+
+      - name: Generate Gremlin Server Base Image
+        working-directory: .
+        run: |
+          mvn clean install -pl :gremlin-server -DskipTests -DskipIntegrationTests=true -am && mvn install -Pdocker-images -pl :gremlin-server
+
+      - name: Execute Go tests
+        working-directory: ./gremlin-go
+        run: |
+          docker-compose up --exit-code-from gremlin-go-integration-tests
+          docker-compose down
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          working-directory: ./gremlin-go
+
+      - name: Go-Vet
+        working-directory: ./gremlin-go
+        run: go vet ./...

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,19 +1,19 @@
 name: build-test
 on: [push, pull_request]
 jobs:
-#  smoke:
-#    name: smoke
-#    timeout-minutes: 10
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: mvn clean install -DskipTests -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  smoke:
+    name: smoke
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: mvn clean install -DskipTests -Dci --batch-mode -D"org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener"="warn"
 #  java-jdk11:
 #    name: mvn clean install - jdk11
 #    timeout-minutes: 45

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
       - name: Build with Maven
-        run: mvn clean install -DskipTests -Dci --batch-mode -D"org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener"="warn"
+        run: mvn clean install -DskipTests -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
   java-jdk11:
     name: mvn clean install - jdk11
     timeout-minutes: 45

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,19 +1,19 @@
 name: build-test
 on: [push, pull_request]
 jobs:
-  smoke:
-    name: smoke
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: mvn clean install -DskipTests -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+#  smoke:
+#    name: smoke
+#    timeout-minutes: 10
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: mvn clean install -DskipTests -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 #  java-jdk11:
 #    name: mvn clean install - jdk11
 #    timeout-minutes: 45
@@ -125,7 +125,7 @@ jobs:
   javascript:
     name: javascript
     timeout-minutes: 15
-    needs: smoke
+#    needs: smoke
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -126,7 +126,10 @@ jobs:
     name: javascript
     timeout-minutes: 15
 #    needs: smoke
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,34 +14,34 @@ jobs:
           distribution: 'temurin'
       - name: Build with Maven
         run: mvn clean install -DskipTests -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-#  java-jdk11:
-#    name: mvn clean install - jdk11
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'adopt'
-#      - name: Build with Maven
-#        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-#  java-jdk8:
-#    name: mvn clean install - jdk8
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 8
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '8'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  java-jdk11:
+    name: mvn clean install - jdk11
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Build with Maven
+        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  java-jdk8:
+    name: mvn clean install - jdk8
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
   gremlin-server-default:
     name: gremlin-server default
     timeout-minutes: 45
@@ -74,54 +74,54 @@ jobs:
         run: |
           mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
           mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j -DtestUnified=true
-#  spark-core:
-#    name: spark core
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false '-Dit.test=*IntegrateTest,!SparkGryoSerializerGraphComputerProcessIntegrateTest'
-#  spark-gryo:
-#    name: spark gryo
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false -Dit.test=SparkGryoSerializerGraphComputerProcessIntegrateTest
-#  gremlin-console:
-#    name: gremlin-console
-#    timeout-minutes: 20
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :gremlin-console -DskipTests -DskipIntegrationTests=false
+  spark-core:
+    name: spark core
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false '-Dit.test=*IntegrateTest,!SparkGryoSerializerGraphComputerProcessIntegrateTest'
+  spark-gryo:
+    name: spark gryo
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false -Dit.test=SparkGryoSerializerGraphComputerProcessIntegrateTest
+  gremlin-console:
+    name: gremlin-console
+    timeout-minutes: 20
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :gremlin-console -DskipTests -DskipIntegrationTests=false
   javascript:
     name: javascript
     timeout-minutes: 15
@@ -141,100 +141,100 @@ jobs:
         run: |
           mvn clean install -pl -:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
           mvn verify -pl :gremlin-javascript,:gremlint -DincludeNeo4j
-#  python:
-#    name: python
-#    timeout-minutes: 20
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Set up Python 3.x
-#        uses: actions/setup-python@v3
-#        with:
-#          python-version: '3.8'
-#      - name: Setup Python requirements
-#        run: |
-#          sudo apt install gcc libkrb5-dev
-#          python3 -m pip install --upgrade pip
-#          pip install virtualenv
-#      - name: Build with Maven
-#        run: |
-#          touch gremlin-python/.glv
-#          mvn clean install -pl -:gremlin-javascript,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl gremlin-python -DincludeNeo4j
-#  dotnet:
-#    name: .NET
-#    timeout-minutes: 20
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Set up .NET 6.0.x
-#        uses: actions/setup-dotnet@v2
-#        with:
-#          dotnet-version: '6.0.x'
-#      - name: Build with Maven
-#        run: |
-#          touch gremlin-dotnet/src/.glv
-#          touch gremlin-dotnet/test/.glv
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :gremlin-dotnet,:gremlin-dotnet-tests -P gremlin-dotnet -DincludeNeo4j
-#  neo4j-gremlin:
-#    name: neo4j-gremlin
-#    timeout-minutes: 20
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
-#          mvn verify -pl :neo4j-gremlin -DincludeNeo4j
-#  go:
-#    name: go
-#    timeout-minutes: 20
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v3
-#
-#      - name: Setup Go
-#        uses: actions/setup-go@v3
-#        with:
-#          go-version: '1.17'
-#
-#      - name: Generate Gremlin Server Base Image
-#        working-directory: .
-#        run: |
-#          mvn clean install -pl :gremlin-server -DskipTests -DskipIntegrationTests=true -am && mvn install -Pdocker-images -pl :gremlin-server
-#
-#      - name: Execute Go tests
-#        working-directory: ./gremlin-go
-#        run: |
-#          docker-compose up --exit-code-from gremlin-go-integration-tests
-#          docker-compose down
-#
-#      - name: Upload to Codecov
-#        uses: codecov/codecov-action@v2
-#        with:
-#          working-directory: ./gremlin-go
-#
-#      - name: Go-Vet
-#        working-directory: ./gremlin-go
-#        run: go vet ./...
+  python:
+    name: python
+    timeout-minutes: 20
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+      - name: Setup Python requirements
+        run: |
+          sudo apt install gcc libkrb5-dev
+          python3 -m pip install --upgrade pip
+          pip install virtualenv
+      - name: Build with Maven
+        run: |
+          touch gremlin-python/.glv
+          mvn clean install -pl -:gremlin-javascript,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl gremlin-python -DincludeNeo4j
+  dotnet:
+    name: .NET
+    timeout-minutes: 20
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Set up .NET 6.0.x
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '6.0.x'
+      - name: Build with Maven
+        run: |
+          touch gremlin-dotnet/src/.glv
+          touch gremlin-dotnet/test/.glv
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :gremlin-dotnet,:gremlin-dotnet-tests -P gremlin-dotnet -DincludeNeo4j
+  neo4j-gremlin:
+    name: neo4j-gremlin
+    timeout-minutes: 20
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
+          mvn verify -pl :neo4j-gremlin -DincludeNeo4j
+  go:
+    name: go
+    timeout-minutes: 20
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.17'
+
+      - name: Generate Gremlin Server Base Image
+        working-directory: .
+        run: |
+          mvn clean install -pl :gremlin-server -DskipTests -DskipIntegrationTests=true -am && mvn install -Pdocker-images -pl :gremlin-server
+
+      - name: Execute Go tests
+        working-directory: ./gremlin-go
+        run: |
+          docker-compose up --exit-code-from gremlin-go-integration-tests
+          docker-compose down
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          working-directory: ./gremlin-go
+
+      - name: Go-Vet
+        working-directory: ./gremlin-go
+        run: go vet ./...

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -129,7 +129,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,114 +14,114 @@ jobs:
           distribution: 'temurin'
       - name: Build with Maven
         run: mvn clean install -DskipTests -Dci --batch-mode -D"org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener"="warn"
-  java-jdk11:
-    name: mvn clean install - jdk11
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-      - name: Build with Maven
-        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-  java-jdk8:
-    name: mvn clean install - jdk8
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 8
-        uses: actions/setup-java@v3
-        with:
-          java-version: '8'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-  gremlin-server-default:
-    name: gremlin-server default
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j
-  gremlin-server-unified:
-    name: gremlin-server unified
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j -DtestUnified=true
-  spark-core:
-    name: spark core
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false '-Dit.test=*IntegrateTest,!SparkGryoSerializerGraphComputerProcessIntegrateTest'
-  spark-gryo:
-    name: spark gryo
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false -Dit.test=SparkGryoSerializerGraphComputerProcessIntegrateTest
-  gremlin-console:
-    name: gremlin-console
-    timeout-minutes: 20
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :gremlin-console -DskipTests -DskipIntegrationTests=false
+#  java-jdk11:
+#    name: mvn clean install - jdk11
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'adopt'
+#      - name: Build with Maven
+#        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+#  java-jdk8:
+#    name: mvn clean install - jdk8
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 8
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '8'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+#  gremlin-server-default:
+#    name: gremlin-server default
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j
+#  gremlin-server-unified:
+#    name: gremlin-server unified
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j -DtestUnified=true
+#  spark-core:
+#    name: spark core
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false '-Dit.test=*IntegrateTest,!SparkGryoSerializerGraphComputerProcessIntegrateTest'
+#  spark-gryo:
+#    name: spark gryo
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false -Dit.test=SparkGryoSerializerGraphComputerProcessIntegrateTest
+#  gremlin-console:
+#    name: gremlin-console
+#    timeout-minutes: 20
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :gremlin-console -DskipTests -DskipIntegrationTests=false
   javascript:
     name: javascript
     timeout-minutes: 15
@@ -167,74 +167,74 @@ jobs:
           touch gremlin-python/.glv
           mvn clean install -pl -:gremlin-javascript,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
           mvn verify -pl gremlin-python -DincludeNeo4j
-  dotnet:
-    name: .NET
-    timeout-minutes: 20
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Set up .NET 6.0.x
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: '6.0.x'
-      - name: Build with Maven
-        run: |
-          touch gremlin-dotnet/src/.glv
-          touch gremlin-dotnet/test/.glv
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :gremlin-dotnet,:gremlin-dotnet-tests -P gremlin-dotnet -DincludeNeo4j
-  neo4j-gremlin:
-    name: neo4j-gremlin
-    timeout-minutes: 20
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
-          mvn verify -pl :neo4j-gremlin -DincludeNeo4j
-  go:
-    name: go
-    timeout-minutes: 20
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.17'
-
-      - name: Generate Gremlin Server Base Image
-        working-directory: .
-        run: |
-          mvn clean install -pl :gremlin-server -DskipTests -DskipIntegrationTests=true -am && mvn install -Pdocker-images -pl :gremlin-server
-
-      - name: Execute Go tests
-        working-directory: ./gremlin-go
-        run: |
-          docker-compose up --exit-code-from gremlin-go-integration-tests
-          docker-compose down
-
-      - name: Upload to Codecov
-        uses: codecov/codecov-action@v2
-        with:
-          working-directory: ./gremlin-go
-
-      - name: Go-Vet
-        working-directory: ./gremlin-go
-        run: go vet ./...
+#  dotnet:
+#    name: .NET
+#    timeout-minutes: 20
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Set up .NET 6.0.x
+#        uses: actions/setup-dotnet@v2
+#        with:
+#          dotnet-version: '6.0.x'
+#      - name: Build with Maven
+#        run: |
+#          touch gremlin-dotnet/src/.glv
+#          touch gremlin-dotnet/test/.glv
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :gremlin-dotnet,:gremlin-dotnet-tests -P gremlin-dotnet -DincludeNeo4j
+#  neo4j-gremlin:
+#    name: neo4j-gremlin
+#    timeout-minutes: 20
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
+#          mvn verify -pl :neo4j-gremlin -DincludeNeo4j
+#  go:
+#    name: go
+#    timeout-minutes: 20
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#
+#      - name: Setup Go
+#        uses: actions/setup-go@v3
+#        with:
+#          go-version: '1.17'
+#
+#      - name: Generate Gremlin Server Base Image
+#        working-directory: .
+#        run: |
+#          mvn clean install -pl :gremlin-server -DskipTests -DskipIntegrationTests=true -am && mvn install -Pdocker-images -pl :gremlin-server
+#
+#      - name: Execute Go tests
+#        working-directory: ./gremlin-go
+#        run: |
+#          docker-compose up --exit-code-from gremlin-go-integration-tests
+#          docker-compose down
+#
+#      - name: Upload to Codecov
+#        uses: codecov/codecov-action@v2
+#        with:
+#          working-directory: ./gremlin-go
+#
+#      - name: Go-Vet
+#        working-directory: ./gremlin-go
+#        run: go vet ./...

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -42,38 +42,38 @@ jobs:
 #          distribution: 'temurin'
 #      - name: Build with Maven
 #        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-#  gremlin-server-default:
-#    name: gremlin-server default
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j
-#  gremlin-server-unified:
-#    name: gremlin-server unified
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j -DtestUnified=true
+  gremlin-server-default:
+    name: gremlin-server default
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j
+  gremlin-server-unified:
+    name: gremlin-server unified
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j -DtestUnified=true
 #  spark-core:
 #    name: spark core
 #    timeout-minutes: 45

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,119 +14,122 @@ jobs:
           distribution: 'temurin'
       - name: Build with Maven
         run: mvn clean install -DskipTests -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-  java-jdk11:
-    name: mvn clean install - jdk11
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-      - name: Build with Maven
-        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-  java-jdk8:
-    name: mvn clean install - jdk8
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 8
-        uses: actions/setup-java@v3
-        with:
-          java-version: '8'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-  gremlin-server-default:
-    name: gremlin-server default
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j
-  gremlin-server-unified:
-    name: gremlin-server unified
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j -DtestUnified=true
-  spark-core:
-    name: spark core
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false '-Dit.test=*IntegrateTest,!SparkGryoSerializerGraphComputerProcessIntegrateTest'
-  spark-gryo:
-    name: spark gryo
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false -Dit.test=SparkGryoSerializerGraphComputerProcessIntegrateTest
-  gremlin-console:
-    name: gremlin-console
-    timeout-minutes: 20
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :gremlin-console -DskipTests -DskipIntegrationTests=false
+#  java-jdk11:
+#    name: mvn clean install - jdk11
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'adopt'
+#      - name: Build with Maven
+#        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+#  java-jdk8:
+#    name: mvn clean install - jdk8
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 8
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '8'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+#  gremlin-server-default:
+#    name: gremlin-server default
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j
+#  gremlin-server-unified:
+#    name: gremlin-server unified
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j -DtestUnified=true
+#  spark-core:
+#    name: spark core
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false '-Dit.test=*IntegrateTest,!SparkGryoSerializerGraphComputerProcessIntegrateTest'
+#  spark-gryo:
+#    name: spark gryo
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false -Dit.test=SparkGryoSerializerGraphComputerProcessIntegrateTest
+#  gremlin-console:
+#    name: gremlin-console
+#    timeout-minutes: 20
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :gremlin-console -DskipTests -DskipIntegrationTests=false
   javascript:
     name: javascript
     timeout-minutes: 15
     needs: smoke
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+      strategy:
+        matrix:
+          os: [ ubuntu-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11
@@ -138,100 +141,100 @@ jobs:
         run: |
           mvn clean install -pl -:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
           mvn verify -pl :gremlin-javascript,:gremlint -DincludeNeo4j
-  python:
-    name: python
-    timeout-minutes: 20
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v3
-        with:
-          python-version: '3.8'
-      - name: Setup Python requirements
-        run: |
-          sudo apt install gcc libkrb5-dev
-          python3 -m pip install --upgrade pip
-          pip install virtualenv
-      - name: Build with Maven
-        run: |
-          touch gremlin-python/.glv
-          mvn clean install -pl -:gremlin-javascript,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl gremlin-python -DincludeNeo4j
-  dotnet:
-    name: .NET
-    timeout-minutes: 20
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Set up .NET 6.0.x
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: '6.0.x'
-      - name: Build with Maven
-        run: |
-          touch gremlin-dotnet/src/.glv
-          touch gremlin-dotnet/test/.glv
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :gremlin-dotnet,:gremlin-dotnet-tests -P gremlin-dotnet -DincludeNeo4j
-  neo4j-gremlin:
-    name: neo4j-gremlin
-    timeout-minutes: 20
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
-          mvn verify -pl :neo4j-gremlin -DincludeNeo4j
-  go:
-    name: go
-    timeout-minutes: 20
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.17'
-
-      - name: Generate Gremlin Server Base Image
-        working-directory: .
-        run: |
-          mvn clean install -pl :gremlin-server -DskipTests -DskipIntegrationTests=true -am && mvn install -Pdocker-images -pl :gremlin-server
-
-      - name: Execute Go tests
-        working-directory: ./gremlin-go
-        run: |
-          docker-compose up --exit-code-from gremlin-go-integration-tests
-          docker-compose down
-
-      - name: Upload to Codecov
-        uses: codecov/codecov-action@v2
-        with:
-          working-directory: ./gremlin-go
-
-      - name: Go-Vet
-        working-directory: ./gremlin-go
-        run: go vet ./...
+#  python:
+#    name: python
+#    timeout-minutes: 20
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Set up Python 3.x
+#        uses: actions/setup-python@v3
+#        with:
+#          python-version: '3.8'
+#      - name: Setup Python requirements
+#        run: |
+#          sudo apt install gcc libkrb5-dev
+#          python3 -m pip install --upgrade pip
+#          pip install virtualenv
+#      - name: Build with Maven
+#        run: |
+#          touch gremlin-python/.glv
+#          mvn clean install -pl -:gremlin-javascript,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl gremlin-python -DincludeNeo4j
+#  dotnet:
+#    name: .NET
+#    timeout-minutes: 20
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Set up .NET 6.0.x
+#        uses: actions/setup-dotnet@v2
+#        with:
+#          dotnet-version: '6.0.x'
+#      - name: Build with Maven
+#        run: |
+#          touch gremlin-dotnet/src/.glv
+#          touch gremlin-dotnet/test/.glv
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :gremlin-dotnet,:gremlin-dotnet-tests -P gremlin-dotnet -DincludeNeo4j
+#  neo4j-gremlin:
+#    name: neo4j-gremlin
+#    timeout-minutes: 20
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
+#          mvn verify -pl :neo4j-gremlin -DincludeNeo4j
+#  go:
+#    name: go
+#    timeout-minutes: 20
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#
+#      - name: Setup Go
+#        uses: actions/setup-go@v3
+#        with:
+#          go-version: '1.17'
+#
+#      - name: Generate Gremlin Server Base Image
+#        working-directory: .
+#        run: |
+#          mvn clean install -pl :gremlin-server -DskipTests -DskipIntegrationTests=true -am && mvn install -Pdocker-images -pl :gremlin-server
+#
+#      - name: Execute Go tests
+#        working-directory: ./gremlin-go
+#        run: |
+#          docker-compose up --exit-code-from gremlin-go-integration-tests
+#          docker-compose down
+#
+#      - name: Upload to Codecov
+#        uses: codecov/codecov-action@v2
+#        with:
+#          working-directory: ./gremlin-go
+#
+#      - name: Go-Vet
+#        working-directory: ./gremlin-go
+#        run: go vet ./...

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,34 +14,34 @@ jobs:
           distribution: 'temurin'
       - name: Build with Maven
         run: mvn clean install -DskipTests -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-#  java-jdk11:
-#    name: mvn clean install - jdk11
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'adopt'
-#      - name: Build with Maven
-#        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-#  java-jdk8:
-#    name: mvn clean install - jdk8
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 8
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '8'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  java-jdk11:
+    name: mvn clean install - jdk11
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Build with Maven
+        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  java-jdk8:
+    name: mvn clean install - jdk8
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 #  gremlin-server-default:
 #    name: gremlin-server default
 #    timeout-minutes: 45

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -127,9 +127,9 @@ jobs:
     timeout-minutes: 15
     needs: smoke
     runs-on: ${{ matrix.os }}
-      strategy:
-        matrix:
-          os: [ ubuntu-latest, windows-latest ]
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,114 +14,114 @@ jobs:
           distribution: 'temurin'
       - name: Build with Maven
         run: mvn clean install -DskipTests -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-  java-jdk11:
-    name: mvn clean install - jdk11
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-      - name: Build with Maven
-        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-  java-jdk8:
-    name: mvn clean install - jdk8
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 8
-        uses: actions/setup-java@v3
-        with:
-          java-version: '8'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-  gremlin-server-default:
-    name: gremlin-server default
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j
-  gremlin-server-unified:
-    name: gremlin-server unified
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j -DtestUnified=true
-  spark-core:
-    name: spark core
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false '-Dit.test=*IntegrateTest,!SparkGryoSerializerGraphComputerProcessIntegrateTest'
-  spark-gryo:
-    name: spark gryo
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false -Dit.test=SparkGryoSerializerGraphComputerProcessIntegrateTest
-  gremlin-console:
-    name: gremlin-console
-    timeout-minutes: 20
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :gremlin-console -DskipTests -DskipIntegrationTests=false
+#  java-jdk11:
+#    name: mvn clean install - jdk11
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'adopt'
+#      - name: Build with Maven
+#        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+#  java-jdk8:
+#    name: mvn clean install - jdk8
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 8
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '8'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+#  gremlin-server-default:
+#    name: gremlin-server default
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j
+#  gremlin-server-unified:
+#    name: gremlin-server unified
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j -DtestUnified=true
+#  spark-core:
+#    name: spark core
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false '-Dit.test=*IntegrateTest,!SparkGryoSerializerGraphComputerProcessIntegrateTest'
+#  spark-gryo:
+#    name: spark gryo
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false -Dit.test=SparkGryoSerializerGraphComputerProcessIntegrateTest
+#  gremlin-console:
+#    name: gremlin-console
+#    timeout-minutes: 20
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :gremlin-console -DskipTests -DskipIntegrationTests=false
   javascript:
     name: javascript
     timeout-minutes: 15
@@ -141,100 +141,100 @@ jobs:
         run: |
           mvn clean install -pl -:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
           mvn verify -pl :gremlin-javascript,:gremlint -DincludeNeo4j
-  python:
-    name: python
-    timeout-minutes: 20
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v3
-        with:
-          python-version: '3.8'
-      - name: Setup Python requirements
-        run: |
-          sudo apt install gcc libkrb5-dev
-          python3 -m pip install --upgrade pip
-          pip install virtualenv
-      - name: Build with Maven
-        run: |
-          touch gremlin-python/.glv
-          mvn clean install -pl -:gremlin-javascript,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl gremlin-python -DincludeNeo4j
-  dotnet:
-    name: .NET
-    timeout-minutes: 20
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Set up .NET 6.0.x
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: '6.0.x'
-      - name: Build with Maven
-        run: |
-          touch gremlin-dotnet/src/.glv
-          touch gremlin-dotnet/test/.glv
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :gremlin-dotnet,:gremlin-dotnet-tests -P gremlin-dotnet -DincludeNeo4j
-  neo4j-gremlin:
-    name: neo4j-gremlin
-    timeout-minutes: 20
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
-          mvn verify -pl :neo4j-gremlin -DincludeNeo4j
-  go:
-    name: go
-    timeout-minutes: 20
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.17'
-
-      - name: Generate Gremlin Server Base Image
-        working-directory: .
-        run: |
-          mvn clean install -pl :gremlin-server -DskipTests -DskipIntegrationTests=true -am && mvn install -Pdocker-images -pl :gremlin-server
-
-      - name: Execute Go tests
-        working-directory: ./gremlin-go
-        run: |
-          docker-compose up --exit-code-from gremlin-go-integration-tests
-          docker-compose down
-
-      - name: Upload to Codecov
-        uses: codecov/codecov-action@v2
-        with:
-          working-directory: ./gremlin-go
-
-      - name: Go-Vet
-        working-directory: ./gremlin-go
-        run: go vet ./...
+#  python:
+#    name: python
+#    timeout-minutes: 20
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Set up Python 3.x
+#        uses: actions/setup-python@v3
+#        with:
+#          python-version: '3.8'
+#      - name: Setup Python requirements
+#        run: |
+#          sudo apt install gcc libkrb5-dev
+#          python3 -m pip install --upgrade pip
+#          pip install virtualenv
+#      - name: Build with Maven
+#        run: |
+#          touch gremlin-python/.glv
+#          mvn clean install -pl -:gremlin-javascript,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl gremlin-python -DincludeNeo4j
+#  dotnet:
+#    name: .NET
+#    timeout-minutes: 20
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Set up .NET 6.0.x
+#        uses: actions/setup-dotnet@v2
+#        with:
+#          dotnet-version: '6.0.x'
+#      - name: Build with Maven
+#        run: |
+#          touch gremlin-dotnet/src/.glv
+#          touch gremlin-dotnet/test/.glv
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :gremlin-dotnet,:gremlin-dotnet-tests -P gremlin-dotnet -DincludeNeo4j
+#  neo4j-gremlin:
+#    name: neo4j-gremlin
+#    timeout-minutes: 20
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
+#          mvn verify -pl :neo4j-gremlin -DincludeNeo4j
+#  go:
+#    name: go
+#    timeout-minutes: 20
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#
+#      - name: Setup Go
+#        uses: actions/setup-go@v3
+#        with:
+#          go-version: '1.17'
+#
+#      - name: Generate Gremlin Server Base Image
+#        working-directory: .
+#        run: |
+#          mvn clean install -pl :gremlin-server -DskipTests -DskipIntegrationTests=true -am && mvn install -Pdocker-images -pl :gremlin-server
+#
+#      - name: Execute Go tests
+#        working-directory: ./gremlin-go
+#        run: |
+#          docker-compose up --exit-code-from gremlin-go-integration-tests
+#          docker-compose down
+#
+#      - name: Upload to Codecov
+#        uses: codecov/codecov-action@v2
+#        with:
+#          working-directory: ./gremlin-go
+#
+#      - name: Go-Vet
+#        working-directory: ./gremlin-go
+#        run: go vet ./...

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -42,86 +42,86 @@ jobs:
           distribution: 'temurin'
       - name: Build with Maven
         run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-#  gremlin-server-default:
-#    name: gremlin-server default
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j
-#  gremlin-server-unified:
-#    name: gremlin-server unified
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j -DtestUnified=true
-#  spark-core:
-#    name: spark core
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false '-Dit.test=*IntegrateTest,!SparkGryoSerializerGraphComputerProcessIntegrateTest'
-#  spark-gryo:
-#    name: spark gryo
-#    timeout-minutes: 45
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false -Dit.test=SparkGryoSerializerGraphComputerProcessIntegrateTest
-#  gremlin-console:
-#    name: gremlin-console
-#    timeout-minutes: 20
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :gremlin-console -DskipTests -DskipIntegrationTests=false
+  gremlin-server-default:
+    name: gremlin-server default
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j
+  gremlin-server-unified:
+    name: gremlin-server unified
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j -DtestUnified=true
+  spark-core:
+    name: spark core
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false '-Dit.test=*IntegrateTest,!SparkGryoSerializerGraphComputerProcessIntegrateTest'
+  spark-gryo:
+    name: spark gryo
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false -Dit.test=SparkGryoSerializerGraphComputerProcessIntegrateTest
+  gremlin-console:
+    name: gremlin-console
+    timeout-minutes: 20
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :gremlin-console -DskipTests -DskipIntegrationTests=false
   javascript:
     name: javascript
     timeout-minutes: 15
@@ -141,100 +141,100 @@ jobs:
         run: |
           mvn clean install -pl -:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
           mvn verify -pl :gremlin-javascript,:gremlint -DincludeNeo4j
-#  python:
-#    name: python
-#    timeout-minutes: 20
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Set up Python 3.x
-#        uses: actions/setup-python@v3
-#        with:
-#          python-version: '3.8'
-#      - name: Setup Python requirements
-#        run: |
-#          sudo apt install gcc libkrb5-dev
-#          python3 -m pip install --upgrade pip
-#          pip install virtualenv
-#      - name: Build with Maven
-#        run: |
-#          touch gremlin-python/.glv
-#          mvn clean install -pl -:gremlin-javascript,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl gremlin-python -DincludeNeo4j
-#  dotnet:
-#    name: .NET
-#    timeout-minutes: 20
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Set up .NET 6.0.x
-#        uses: actions/setup-dotnet@v2
-#        with:
-#          dotnet-version: '6.0.x'
-#      - name: Build with Maven
-#        run: |
-#          touch gremlin-dotnet/src/.glv
-#          touch gremlin-dotnet/test/.glv
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-:gremlint -q -DskipTests -Dci
-#          mvn verify -pl :gremlin-dotnet,:gremlin-dotnet-tests -P gremlin-dotnet -DincludeNeo4j
-#  neo4j-gremlin:
-#    name: neo4j-gremlin
-#    timeout-minutes: 20
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up JDK11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'temurin'
-#      - name: Build with Maven
-#        run: |
-#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
-#          mvn verify -pl :neo4j-gremlin -DincludeNeo4j
-#  go:
-#    name: go
-#    timeout-minutes: 20
-#    needs: smoke
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v3
-#
-#      - name: Setup Go
-#        uses: actions/setup-go@v3
-#        with:
-#          go-version: '1.17'
-#
-#      - name: Generate Gremlin Server Base Image
-#        working-directory: .
-#        run: |
-#          mvn clean install -pl :gremlin-server -DskipTests -DskipIntegrationTests=true -am && mvn install -Pdocker-images -pl :gremlin-server
-#
-#      - name: Execute Go tests
-#        working-directory: ./gremlin-go
-#        run: |
-#          docker-compose up --exit-code-from gremlin-go-integration-tests
-#          docker-compose down
-#
-#      - name: Upload to Codecov
-#        uses: codecov/codecov-action@v2
-#        with:
-#          working-directory: ./gremlin-go
-#
-#      - name: Go-Vet
-#        working-directory: ./gremlin-go
-#        run: go vet ./...
+  python:
+    name: python
+    timeout-minutes: 20
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+      - name: Setup Python requirements
+        run: |
+          sudo apt install gcc libkrb5-dev
+          python3 -m pip install --upgrade pip
+          pip install virtualenv
+      - name: Build with Maven
+        run: |
+          touch gremlin-python/.glv
+          mvn clean install -pl -:gremlin-javascript,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl gremlin-python -DincludeNeo4j
+  dotnet:
+    name: .NET
+    timeout-minutes: 20
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Set up .NET 6.0.x
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '6.0.x'
+      - name: Build with Maven
+        run: |
+          touch gremlin-dotnet/src/.glv
+          touch gremlin-dotnet/test/.glv
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl :gremlin-dotnet,:gremlin-dotnet-tests -P gremlin-dotnet -DincludeNeo4j
+  neo4j-gremlin:
+    name: neo4j-gremlin
+    timeout-minutes: 20
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
+          mvn verify -pl :neo4j-gremlin -DincludeNeo4j
+  go:
+    name: go
+    timeout-minutes: 20
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.17'
+
+      - name: Generate Gremlin Server Base Image
+        working-directory: .
+        run: |
+          mvn clean install -pl :gremlin-server -DskipTests -DskipIntegrationTests=true -am && mvn install -Pdocker-images -pl :gremlin-server
+
+      - name: Execute Go tests
+        working-directory: ./gremlin-go
+        run: |
+          docker-compose up --exit-code-from gremlin-go-integration-tests
+          docker-compose down
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          working-directory: ./gremlin-go
+
+      - name: Go-Vet
+        working-directory: ./gremlin-go
+        run: go vet ./...

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,114 +14,114 @@ jobs:
           distribution: 'temurin'
       - name: Build with Maven
         run: mvn clean install -DskipTests -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-  java-jdk11:
-    name: mvn clean install - jdk11
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-      - name: Build with Maven
-        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-  java-jdk8:
-    name: mvn clean install - jdk8
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 8
-        uses: actions/setup-java@v3
-        with:
-          java-version: '8'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-  gremlin-server-default:
-    name: gremlin-server default
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j
-  gremlin-server-unified:
-    name: gremlin-server unified
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j -DtestUnified=true
-  spark-core:
-    name: spark core
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false '-Dit.test=*IntegrateTest,!SparkGryoSerializerGraphComputerProcessIntegrateTest'
-  spark-gryo:
-    name: spark gryo
-    timeout-minutes: 45
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false -Dit.test=SparkGryoSerializerGraphComputerProcessIntegrateTest
-  gremlin-console:
-    name: gremlin-console
-    timeout-minutes: 20
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :gremlin-console -DskipTests -DskipIntegrationTests=false
+#  java-jdk11:
+#    name: mvn clean install - jdk11
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'adopt'
+#      - name: Build with Maven
+#        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+#  java-jdk8:
+#    name: mvn clean install - jdk8
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 8
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '8'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: mvn clean install -pl -:gremlin-javascript -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+#  gremlin-server-default:
+#    name: gremlin-server default
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j
+#  gremlin-server-unified:
+#    name: gremlin-server unified
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :gremlin-server -DskipTests -DskipIntegrationTests=false -DincludeNeo4j -DtestUnified=true
+#  spark-core:
+#    name: spark core
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false '-Dit.test=*IntegrateTest,!SparkGryoSerializerGraphComputerProcessIntegrateTest'
+#  spark-gryo:
+#    name: spark gryo
+#    timeout-minutes: 45
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :spark-gremlin -DskipTests -DskipIntegrationTests=false -Dit.test=SparkGryoSerializerGraphComputerProcessIntegrateTest
+#  gremlin-console:
+#    name: gremlin-console
+#    timeout-minutes: 20
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :gremlin-console -DskipTests -DskipIntegrationTests=false
   javascript:
     name: javascript
     timeout-minutes: 15
@@ -138,100 +138,100 @@ jobs:
         run: |
           mvn clean install -pl -:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
           mvn verify -pl :gremlin-javascript,:gremlint -DincludeNeo4j
-  python:
-    name: python
-    timeout-minutes: 20
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v3
-        with:
-          python-version: '3.8'
-      - name: Setup Python requirements
-        run: |
-          sudo apt install gcc libkrb5-dev
-          python3 -m pip install --upgrade pip
-          pip install virtualenv
-      - name: Build with Maven
-        run: |
-          touch gremlin-python/.glv
-          mvn clean install -pl -:gremlin-javascript,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl gremlin-python -DincludeNeo4j
-  dotnet:
-    name: .NET
-    timeout-minutes: 20
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Set up .NET 6.0.x
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: '6.0.x'
-      - name: Build with Maven
-        run: |
-          touch gremlin-dotnet/src/.glv
-          touch gremlin-dotnet/test/.glv
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :gremlin-dotnet,:gremlin-dotnet-tests -P gremlin-dotnet -DincludeNeo4j
-  neo4j-gremlin:
-    name: neo4j-gremlin
-    timeout-minutes: 20
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
-          mvn verify -pl :neo4j-gremlin -DincludeNeo4j
-  go:
-    name: go
-    timeout-minutes: 20
-    needs: smoke
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.17'
-
-      - name: Generate Gremlin Server Base Image
-        working-directory: .
-        run: |
-          mvn clean install -pl :gremlin-server -DskipTests -DskipIntegrationTests=true -am && mvn install -Pdocker-images -pl :gremlin-server
-
-      - name: Execute Go tests
-        working-directory: ./gremlin-go
-        run: |
-          docker-compose up --exit-code-from gremlin-go-integration-tests
-          docker-compose down
-
-      - name: Upload to Codecov
-        uses: codecov/codecov-action@v2
-        with:
-          working-directory: ./gremlin-go
-
-      - name: Go-Vet
-        working-directory: ./gremlin-go
-        run: go vet ./...
+#  python:
+#    name: python
+#    timeout-minutes: 20
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Set up Python 3.x
+#        uses: actions/setup-python@v3
+#        with:
+#          python-version: '3.8'
+#      - name: Setup Python requirements
+#        run: |
+#          sudo apt install gcc libkrb5-dev
+#          python3 -m pip install --upgrade pip
+#          pip install virtualenv
+#      - name: Build with Maven
+#        run: |
+#          touch gremlin-python/.glv
+#          mvn clean install -pl -:gremlin-javascript,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl gremlin-python -DincludeNeo4j
+#  dotnet:
+#    name: .NET
+#    timeout-minutes: 20
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Set up .NET 6.0.x
+#        uses: actions/setup-dotnet@v2
+#        with:
+#          dotnet-version: '6.0.x'
+#      - name: Build with Maven
+#        run: |
+#          touch gremlin-dotnet/src/.glv
+#          touch gremlin-dotnet/test/.glv
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-:gremlint -q -DskipTests -Dci
+#          mvn verify -pl :gremlin-dotnet,:gremlin-dotnet-tests -P gremlin-dotnet -DincludeNeo4j
+#  neo4j-gremlin:
+#    name: neo4j-gremlin
+#    timeout-minutes: 20
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#      - name: Build with Maven
+#        run: |
+#          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
+#          mvn verify -pl :neo4j-gremlin -DincludeNeo4j
+#  go:
+#    name: go
+#    timeout-minutes: 20
+#    needs: smoke
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#
+#      - name: Setup Go
+#        uses: actions/setup-go@v3
+#        with:
+#          go-version: '1.17'
+#
+#      - name: Generate Gremlin Server Base Image
+#        working-directory: .
+#        run: |
+#          mvn clean install -pl :gremlin-server -DskipTests -DskipIntegrationTests=true -am && mvn install -Pdocker-images -pl :gremlin-server
+#
+#      - name: Execute Go tests
+#        working-directory: ./gremlin-go
+#        run: |
+#          docker-compose up --exit-code-from gremlin-go-integration-tests
+#          docker-compose down
+#
+#      - name: Upload to Codecov
+#        uses: codecov/codecov-action@v2
+#        with:
+#          working-directory: ./gremlin-go
+#
+#      - name: Go-Vet
+#        working-directory: ./gremlin-go
+#        run: go vet ./...

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -126,10 +126,7 @@ jobs:
     name: javascript
     timeout-minutes: 15
     needs: smoke
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11

--- a/gremlin-dotnet/src/pom.xml
+++ b/gremlin-dotnet/src/pom.xml
@@ -55,15 +55,16 @@ limitations under the License.
                         <configuration>
                             <scripts>
                                 <script>
-def mavenVersion = "${project.version}"
-def file = new File("${project.basedir}/Gremlin.Net/Gremlin.Net.csproj")
-file.write(file.getText("UTF-8").replaceFirst(/&lt;Version&gt;(.*)&lt;\/Version&gt;/, "&lt;Version&gt;" + mavenVersion + "&lt;/Version&gt;"))
+                                    def mavenVersion = "${project.version}"
+                                    def path = new File(".").absolutePath.replace("\\.", "")
+                                    def file = new File(path + "/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj")
+                                    file.write(file.getText("UTF-8").replaceFirst(/&lt;Version&gt;(.*)&lt;\/Version&gt;/, "&lt;Version&gt;" + mavenVersion + "&lt;/Version&gt;"))
 
-file = new File("${project.basedir}/Gremlin.Net.Template/Gremlin.Net.Template.csproj")
-file.write(file.getText("UTF-8").replaceFirst(/Version="(.*)"/, "Version=\"" + mavenVersion + "\""))
+                                    def file = new File(path + "/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.csproj")
+                                    file.write(file.getText("UTF-8").replaceFirst(/Version="(.*)"/, "Version=\"" + mavenVersion + "\""))
 
-file = new File("${project.basedir}/Gremlin.Net.Template/Gremlin.Net.Template.nuspec")
-file.write(file.getText("UTF-8").replaceFirst(/&lt;version&gt;(.*)&lt;\/version&gt;/, "&lt;version&gt;" + mavenVersion + "&lt;/version&gt;"))
+                                    def file = new File(path + "/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.nuspec")
+                                    file.write(file.getText("UTF-8").replaceFirst(/&lt;version&gt;(.*)&lt;\/version&gt;/, "&lt;version&gt;" + mavenVersion + "&lt;/version&gt;"))
                                 </script>
                             </scripts>
                         </configuration>

--- a/gremlin-dotnet/src/pom.xml
+++ b/gremlin-dotnet/src/pom.xml
@@ -63,8 +63,9 @@ file = new File("${project.basedir}/Gremlin.Net.Template/Gremlin.Net.Template.cs
 file.write(file.getText("UTF-8").replaceFirst(/Version="(.*)"/, "Version=\"" + mavenVersion + "\""))
 
 file = new File("${project.basedir}/Gremlin.Net.Template/Gremlin.Net.Template.nuspec")
-file.write(file.getText("UTF-8").replaceFirst(/&lt;version&gt;(.*)&lt;\/version&gt;/, "&lt;version&gt;" + mavenVersion + "&lt;/version&gt;"))                                </script>
-                                </scripts>
+file.write(file.getText("UTF-8").replaceFirst(/&lt;version&gt;(.*)&lt;\/version&gt;/, "&lt;version&gt;" + mavenVersion + "&lt;/version&gt;"))
+                                </script>
+                            </scripts>
                         </configuration>
                     </execution>
                 </executions>

--- a/gremlin-dotnet/src/pom.xml
+++ b/gremlin-dotnet/src/pom.xml
@@ -60,10 +60,10 @@ limitations under the License.
                                     def file = new File(path + "/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj")
                                     file.write(file.getText("UTF-8").replaceFirst(/&lt;Version&gt;(.*)&lt;\/Version&gt;/, "&lt;Version&gt;" + mavenVersion + "&lt;/Version&gt;"))
 
-                                    def file = new File(path + "/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.csproj")
+                                    file = new File(path + "/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.csproj")
                                     file.write(file.getText("UTF-8").replaceFirst(/Version="(.*)"/, "Version=\"" + mavenVersion + "\""))
 
-                                    def file = new File(path + "/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.nuspec")
+                                    file = new File(path + "/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.nuspec")
                                     file.write(file.getText("UTF-8").replaceFirst(/&lt;version&gt;(.*)&lt;\/version&gt;/, "&lt;version&gt;" + mavenVersion + "&lt;/version&gt;"))
                                 </script>
                             </scripts>

--- a/gremlin-dotnet/src/pom.xml
+++ b/gremlin-dotnet/src/pom.xml
@@ -64,7 +64,7 @@ file.write(file.getText("UTF-8").replaceFirst(/Version="(.*)"/, "Version=\"" + m
 
 file = new File("${project.basedir}/Gremlin.Net.Template/Gremlin.Net.Template.nuspec")
 file.write(file.getText("UTF-8").replaceFirst(/&lt;version&gt;(.*)&lt;\/version&gt;/, "&lt;version&gt;" + mavenVersion + "&lt;/version&gt;"))                                </script>
-                            </scripts>
+                                </scripts>
                         </configuration>
                     </execution>
                 </executions>

--- a/gremlin-dotnet/src/pom.xml
+++ b/gremlin-dotnet/src/pom.xml
@@ -56,16 +56,14 @@ limitations under the License.
                             <scripts>
                                 <script>
                                     def mavenVersion = "${project.version}"
-                                    def path = new File(".").absolutePath.replace("\\.", "")
-                                    def file = new File(path + "/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj")
+                                    def file = new File("${project.basedir}/Gremlin.Net/Gremlin.Net.csproj")
                                     file.write(file.getText("UTF-8").replaceFirst(/&lt;Version&gt;(.*)&lt;\/Version&gt;/, "&lt;Version&gt;" + mavenVersion + "&lt;/Version&gt;"))
 
-                                    file = new File(path + "/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.csproj")
+                                    file = new File("${project.basedir}/Gremlin.Net.Template/Gremlin.Net.Template.csproj")
                                     file.write(file.getText("UTF-8").replaceFirst(/Version="(.*)"/, "Version=\"" + mavenVersion + "\""))
 
-                                    file = new File(path + "/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.nuspec")
-                                    file.write(file.getText("UTF-8").replaceFirst(/&lt;version&gt;(.*)&lt;\/version&gt;/, "&lt;version&gt;" + mavenVersion + "&lt;/version&gt;"))
-                                </script>
+                                    file = new File("${project.basedir}/Gremlin.Net.Template/Gremlin.Net.Template.nuspec")
+                                    file.write(file.getText("UTF-8").replaceFirst(/&lt;version&gt;(.*)&lt;\/version&gt;/, "&lt;version&gt;" + mavenVersion + "&lt;/version&gt;"))                                </script>
                             </scripts>
                         </configuration>
                     </execution>

--- a/gremlin-dotnet/src/pom.xml
+++ b/gremlin-dotnet/src/pom.xml
@@ -55,15 +55,15 @@ limitations under the License.
                         <configuration>
                             <scripts>
                                 <script>
-                                    def mavenVersion = "${project.version}"
-                                    def file = new File("${project.basedir}/Gremlin.Net/Gremlin.Net.csproj")
-                                    file.write(file.getText("UTF-8").replaceFirst(/&lt;Version&gt;(.*)&lt;\/Version&gt;/, "&lt;Version&gt;" + mavenVersion + "&lt;/Version&gt;"))
+def mavenVersion = "${project.version}"
+def file = new File("${project.basedir}/Gremlin.Net/Gremlin.Net.csproj")
+file.write(file.getText("UTF-8").replaceFirst(/&lt;Version&gt;(.*)&lt;\/Version&gt;/, "&lt;Version&gt;" + mavenVersion + "&lt;/Version&gt;"))
 
-                                    file = new File("${project.basedir}/Gremlin.Net.Template/Gremlin.Net.Template.csproj")
-                                    file.write(file.getText("UTF-8").replaceFirst(/Version="(.*)"/, "Version=\"" + mavenVersion + "\""))
+file = new File("${project.basedir}/Gremlin.Net.Template/Gremlin.Net.Template.csproj")
+file.write(file.getText("UTF-8").replaceFirst(/Version="(.*)"/, "Version=\"" + mavenVersion + "\""))
 
-                                    file = new File("${project.basedir}/Gremlin.Net.Template/Gremlin.Net.Template.nuspec")
-                                    file.write(file.getText("UTF-8").replaceFirst(/&lt;version&gt;(.*)&lt;\/version&gt;/, "&lt;version&gt;" + mavenVersion + "&lt;/version&gt;"))                                </script>
+file = new File("${project.basedir}/Gremlin.Net.Template/Gremlin.Net.Template.nuspec")
+file.write(file.getText("UTF-8").replaceFirst(/&lt;version&gt;(.*)&lt;\/version&gt;/, "&lt;version&gt;" + mavenVersion + "&lt;/version&gt;"))                                </script>
                             </scripts>
                         </configuration>
                     </execution>

--- a/gremlin-javascript/pom.xml
+++ b/gremlin-javascript/pom.xml
@@ -118,8 +118,8 @@ limitations under the License.
                                 <script>
                                     def mavenVersion = "${project.version}"
                                     def versionForJs = mavenVersion.replace("-SNAPSHOT", "-alpha1")
-                                    def path = new File(".").absolutePath.replace("\\.", "")
-                                    def file = new File(path + "/gremlin-javascript/src/main/javascript/gremlin-javascript/package.json")
+                                    def platformAgnosticBaseDirPath = new File(".").absolutePath.replace("\\.", "").replace("\\", "/")
+                                    def file = new File(platformAgnosticBaseDirPath + "/gremlin-javascript/src/main/javascript/gremlin-javascript/package.json")
                                     file.write(file.getText("UTF-8").replaceFirst(/"version": "(.*)",/, "\"version\": \"" + versionForJs + "\","))
                                 </script>
                             </scripts>
@@ -138,20 +138,8 @@ limitations under the License.
                                     <value>${skipTests}</value>
                                 </property>
                                 <property>
-                                    <name>gremlinServerDir</name>
-                                    <value>${gremlin.server.dir}</value>
-                                </property>
-                                <property>
-                                    <name>settingsFile</name>
-                                    <value>${gremlin.server.dir}/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml</value>
-                                </property>
-                                <property>
                                     <name>executionName</name>
                                     <value>${project.name}</value>
-                                </property>
-                                <property>
-                                    <name>projectBaseDir</name>
-                                    <value>${project.basedir}</value>
                                 </property>
                             </properties>
                             <scripts>

--- a/gremlin-javascript/pom.xml
+++ b/gremlin-javascript/pom.xml
@@ -118,7 +118,7 @@ limitations under the License.
                                 <script>
                                     def mavenVersion = "${project.version}"
                                     def versionForJs = mavenVersion.replace("-SNAPSHOT", "-alpha1")
-                                    def platformAgnosticBaseDirPath = new File(".").absolutePath.replace("\\.", "").replace("\\", "/")
+                                    def platformAgnosticBaseDirPath = new File(".this-definitely-does-not-exist").absolutePath.replace("\\.this-definitely-does-not-exist", "").replace("\\", "/")
                                     def file = new File(platformAgnosticBaseDirPath + "/gremlin-javascript/src/main/javascript/gremlin-javascript/package.json")
                                     file.write(file.getText("UTF-8").replaceFirst(/"version": "(.*)",/, "\"version\": \"" + versionForJs + "\","))
                                 </script>

--- a/gremlin-javascript/pom.xml
+++ b/gremlin-javascript/pom.xml
@@ -116,10 +116,11 @@ limitations under the License.
                         <configuration>
                             <scripts>
                                 <script>
-def mavenVersion = "${project.version}"
-def versionForJs = mavenVersion.replace("-SNAPSHOT", "-alpha1")
-def file = new File("${project.basedir}/src/main/javascript/gremlin-javascript/package.json")
-file.write(file.getText("UTF-8").replaceFirst(/"version": "(.*)",/, "\"version\": \"" + versionForJs + "\","))
+                                    def mavenVersion = "${project.version}"
+                                    def versionForJs = mavenVersion.replace("-SNAPSHOT", "-alpha1")
+                                    def path = new File(".").absolutePath.replace("\\.", "")
+                                    def file = new File(path + "/gremlin-javascript/src/main/javascript/gremlin-javascript/package.json")
+                                    file.write(file.getText("UTF-8").replaceFirst(/"version": "(.*)",/, "\"version\": \"" + versionForJs + "\","))
                                 </script>
                             </scripts>
                         </configuration>

--- a/gremlin-javascript/pom.xml
+++ b/gremlin-javascript/pom.xml
@@ -138,8 +138,20 @@ limitations under the License.
                                     <value>${skipTests}</value>
                                 </property>
                                 <property>
+                                    <name>gremlinServerDir</name>
+                                    <value>${gremlin.server.dir}</value>
+                                </property>
+                                <property>
+                                    <name>settingsFile</name>
+                                    <value>${gremlin.server.dir}/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml</value>
+                                </property>
+                                <property>
                                     <name>executionName</name>
                                     <value>${project.name}</value>
+                                </property>
+                                <property>
+                                    <name>projectBaseDir</name>
+                                    <value>${project.basedir}</value>
                                 </property>
                             </properties>
                             <scripts>

--- a/gremlin-javascript/pom.xml
+++ b/gremlin-javascript/pom.xml
@@ -118,7 +118,7 @@ limitations under the License.
                                 <script>
                                     def mavenVersion = "${project.version}"
                                     def versionForJs = mavenVersion.replace("-SNAPSHOT", "-alpha1")
-                                    def platformAgnosticBaseDirPath = new File(".this-definitely-does-not-exist").absolutePath.replace("\\.this-definitely-does-not-exist", "").replace("\\", "/")
+                                    def platformAgnosticBaseDirPath = new File(".this-definitely-does-not-exist").absolutePath.replace("\\.this-definitely-does-not-exist", "").replace("/.this-definitely-does-not-exist", "").replace("\\", "/")
                                     def file = new File(platformAgnosticBaseDirPath + "/gremlin-javascript/src/main/javascript/gremlin-javascript/package.json")
                                     file.write(file.getText("UTF-8").replaceFirst(/"version": "(.*)",/, "\"version\": \"" + versionForJs + "\","))
                                 </script>

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/.eslintrc.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/.eslintrc.js
@@ -31,9 +31,9 @@ module.exports = {
   extends: ['eslint:recommended', 'prettier'],
   plugins: ['prettier'],
   rules: {
-    'prettier/prettier': ['error'],
+    'prettier/prettier': ['error', { endOfLine: 'auto' }],
     indent: ['error', 2, { SwitchCase: 1 }],
-    'linebreak-style': ['error', 'unix'],
+    'linebreak-style': 0,
     quotes: ['error', 'single'],
     semi: ['error', 'always'],
     'no-constant-condition': ['error', { checkLoops: false }],

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/package.json
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/package.json
@@ -38,9 +38,9 @@
     "url": "https://issues.apache.org/jira/browse/TINKERPOP"
   },
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha test/unit test/integration -t 5000",
-    "features": "./node_modules/.bin/cucumber-js --require test/cucumber ../../../../../gremlin-test/features/",
-    "unit-test": "./node_modules/mocha/bin/mocha test/unit",
+    "test": "mocha test/unit test/integration -t 5000",
+    "features": "cucumber-js --require test/cucumber ../../../../../gremlin-test/features/",
+    "unit-test": "mocha test/unit",
     "lint": "eslint --ext .js ."
   },
   "engines": {

--- a/gremlin-server/src/test/scripts/test-server-start.groovy
+++ b/gremlin-server/src/test/scripts/test-server-start.groovy
@@ -76,7 +76,7 @@ if (!securePropsFile.exists()) {
 }
 
 def settingsSecure = Settings.read("${settingsFile}")
-def platformAgnosticBaseDirPath = new File(".this-definitely-does-not-exist").absolutePath.replace("\\.this-definitely-does-not-exist", "").replace("/.this-definitely-does-not-exist","")
+def platformAgnosticBaseDirPath = new File(".this-definitely-does-not-exist").absolutePath.replace("\\.this-definitely-does-not-exist", "").replace("tinkerpop/.this-definitely-does-not-exist","")
 settingsSecure.graphs.graph = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
 settingsSecure.graphs.classic = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
 settingsSecure.graphs.modern = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"

--- a/gremlin-server/src/test/scripts/test-server-start.groovy
+++ b/gremlin-server/src/test/scripts/test-server-start.groovy
@@ -76,7 +76,7 @@ if (!securePropsFile.exists()) {
 }
 
 def settingsSecure = Settings.read("${settingsFile}")
-def platformAgnosticBaseDirPath = new File(".").absolutePath.replace("\\.", "")
+def platformAgnosticBaseDirPath = new File(".this-definitely-does-not-exist").absolutePath.replace("\\.this-definitely-does-not-exist", "").replace("/.this-definitely-does-not-exist","")
 settingsSecure.graphs.graph = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
 settingsSecure.graphs.classic = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
 settingsSecure.graphs.modern = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"

--- a/gremlin-server/src/test/scripts/test-server-start.groovy
+++ b/gremlin-server/src/test/scripts/test-server-start.groovy
@@ -48,23 +48,25 @@ if (testTransactions) {
 log.info("Starting Gremlin Server instances for native testing of ${executionName}")
 log.info("Transactions validated (enabled with -DincludeNeo4j and only available on port 45940): " + testTransactions)
 
-def settings = Settings.read("${settingsFile}")
-settings.graphs.graph = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settings.graphs.classic = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settings.graphs.modern = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settings.graphs.crew = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settings.graphs.grateful = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settings.graphs.sink = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-if (testTransactions) settings.graphs.tx = gremlinServerDir + "/src/test/scripts/neo4j-empty.properties"
-settings.scriptEngines["gremlin-groovy"].plugins["org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin"].files = [gremlinServerDir + "/src/test/scripts/generate-all.groovy"]
+def platformAgnosticBaseDirPath = new File(".this-definitely-does-not-exist").absolutePath
+        .replace("\\.this-definitely-does-not-exist", "") // Windows
+        .replace("/.this-definitely-does-not-exist","") // Unix
+def platformAgnosticGremlinServerDir = platformAgnosticBaseDirPath + "/gremlin-server"
+def platformAgnosticSettingsFile = platformAgnosticGremlinServerDir + "/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml"
+
+def settings = Settings.read("${platformAgnosticSettingsFile}")
+settings.graphs.graph = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settings.graphs.classic = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settings.graphs.modern = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settings.graphs.crew = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settings.graphs.grateful = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settings.graphs.sink = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+if (testTransactions) settings.graphs.tx = platformAgnosticGremlinServerDir + "/src/test/scripts/neo4j-empty.properties"
+settings.scriptEngines["gremlin-groovy"].plugins["org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin"].files = [platformAgnosticGremlinServerDir + "/src/test/scripts/generate-all.groovy"]
 settings.port = 45940
 
 def server = new GremlinServer(settings)
 server.start().join()
-
-def platformAgnosticBaseDirPath = new File(".this-definitely-does-not-exist").absolutePath
-        .replace("\\.this-definitely-does-not-exist", "") // Windows
-        .replace("tinkerpop/.this-definitely-does-not-exist","") // Unix
 
 project.setContextValue("gremlin.server", server)
 log.info("Gremlin Server without authentication started on port 45940")
@@ -76,25 +78,26 @@ if (!securePropsFile.exists()) {
     securePropsFile.createNewFile()
     securePropsFile << "gremlin.graph=org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph\n"
     securePropsFile << "gremlin.tinkergraph.vertexIdManager=LONG\n"
-    securePropsFile << "gremlin.tinkergraph.graphLocation=${gremlinServerDir}/data/credentials.kryo\n"
+    securePropsFile << "gremlin.tinkergraph.graphLocation=${platformAgnosticGremlinServerDir}/data/credentials.kryo\n"
     securePropsFile << "gremlin.tinkergraph.graphFormat=gryo"
 }
 
-def settingsSecure = Settings.read("${settingsFile}")
-settingsSecure.graphs.graph = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsSecure.graphs.classic = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsSecure.graphs.modern = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsSecure.graphs.crew = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsSecure.graphs.grateful = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsSecure.graphs.sink = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsSecure.scriptEngines["gremlin-groovy"].plugins["org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin"].files = [gremlinServerDir + "/src/test/scripts/generate-all.groovy"]
+def settingsSecure = Settings.read("${platformAgnosticSettingsFile}")
+settingsSecure.graphs.graph = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsSecure.graphs.classic = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsSecure.graphs.modern = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsSecure.graphs.crew = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsSecure.graphs.grateful = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsSecure.graphs.sink = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsSecure.scriptEngines["gremlin-groovy"].plugins["org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin"].files = [platformAgnosticGremlinServerDir + "/src/test/scripts/generate-all.groovy"]
 settingsSecure.port = 45941
 settingsSecure.authentication.authenticator = "org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator"
 settingsSecure.authentication.config = [credentialsDb: platformAgnosticBaseDirPath + "/target/tinkergraph-credentials.properties"]
+log.warn(settingsSecure.authentication.config.get("credentialsDb") + "lmaooo")
 settingsSecure.ssl = new Settings.SslSettings()
 settingsSecure.ssl.enabled = true
 settingsSecure.ssl.sslEnabledProtocols = ["TLSv1.2"]
-settingsSecure.ssl.keyStore = gremlinServerDir + "/src/test/resources/server-key.jks"
+settingsSecure.ssl.keyStore = platformAgnosticGremlinServerDir + "/src/test/resources/server-key.jks"
 settingsSecure.ssl.keyStorePassword = "changeit"
 
 def serverSecure = new GremlinServer(settingsSecure)
@@ -110,14 +113,14 @@ kdcServer.setUp()
 project.setContextValue("gremlin.server.kdcserver", kdcServer)
 log.info("KDC started with configuration ${platformAgnosticBaseDirPath}/target/kdc/krb5.conf")
 
-def settingsKrb5 = Settings.read("${settingsFile}")
-settingsKrb5.graphs.graph = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsKrb5.graphs.classic = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsKrb5.graphs.modern = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsKrb5.graphs.crew = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsKrb5.graphs.grateful = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsKrb5.graphs.sink = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsKrb5.scriptEngines["gremlin-groovy"].plugins["org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin"].files = [gremlinServerDir + "/src/test/scripts/generate-all.groovy"]
+def settingsKrb5 = Settings.read("${platformAgnosticSettingsFile}")
+settingsKrb5.graphs.graph = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsKrb5.graphs.classic = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsKrb5.graphs.modern = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsKrb5.graphs.crew = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsKrb5.graphs.grateful = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsKrb5.graphs.sink = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsKrb5.scriptEngines["gremlin-groovy"].plugins["org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin"].files = [platformAgnosticGremlinServerDir + "/src/test/scripts/generate-all.groovy"]
 settingsKrb5.port = 45942
 settingsKrb5.authentication.authenticator = "org.apache.tinkerpop.gremlin.server.auth.Krb5Authenticator"
 settingsKrb5.authentication.config = [

--- a/gremlin-server/src/test/scripts/test-server-start.groovy
+++ b/gremlin-server/src/test/scripts/test-server-start.groovy
@@ -66,7 +66,7 @@ project.setContextValue("gremlin.server", server)
 log.info("Gremlin Server without authentication started on port 45940")
 
 
-def securePropsFile = new File("${projectBaseDir}/target/tinkergraph-credentials.properties")
+def securePropsFile = new File("${projectBaseDir}${projectBaseDir}/target/tinkergraph-credentials.properties")
 if (!securePropsFile.exists()) {
     securePropsFile.createNewFile()
     securePropsFile << "gremlin.graph=org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph\n"

--- a/gremlin-server/src/test/scripts/test-server-start.groovy
+++ b/gremlin-server/src/test/scripts/test-server-start.groovy
@@ -76,6 +76,7 @@ if (!securePropsFile.exists()) {
 }
 
 def settingsSecure = Settings.read("${settingsFile}")
+def platformAgnosticBaseDirPath = new File(".").absolutePath.replace("\\.", "")
 settingsSecure.graphs.graph = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
 settingsSecure.graphs.classic = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
 settingsSecure.graphs.modern = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
@@ -85,7 +86,7 @@ settingsSecure.graphs.sink = gremlinServerDir + "/src/test/scripts/tinkergraph-e
 settingsSecure.scriptEngines["gremlin-groovy"].plugins["org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin"].files = [gremlinServerDir + "/src/test/scripts/generate-all.groovy"]
 settingsSecure.port = 45941
 settingsSecure.authentication.authenticator = "org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator"
-settingsSecure.authentication.config = [credentialsDb: projectBaseDir + "/target/tinkergraph-credentials.properties"]
+settingsSecure.authentication.config = [credentialsDb: platformAgnosticBaseDirPath + "/target/tinkergraph-credentials.properties"]
 settingsSecure.ssl = new Settings.SslSettings()
 settingsSecure.ssl.enabled = true
 settingsSecure.ssl.sslEnabledProtocols = ["TLSv1.2"]

--- a/gremlin-server/src/test/scripts/test-server-start.groovy
+++ b/gremlin-server/src/test/scripts/test-server-start.groovy
@@ -106,20 +106,20 @@ project.setContextValue("gremlin.server.secure", serverSecure)
 log.info("Gremlin Server with password authentication started on port 45941")
 
 
-def kdcServer = new KdcFixture(platformAgnosticBaseDirPath)
+def kdcServer = new KdcFixture(projectBaseDir)
 kdcServer.setUp()
 
 project.setContextValue("gremlin.server.kdcserver", kdcServer)
-log.info("KDC started with configuration ${platformAgnosticBaseDirPath}/target/kdc/krb5.conf")
+log.info("KDC started with configuration ${projectBaseDir}/target/kdc/krb5.conf")
 
-def settingsKrb5 = Settings.read("${platformAgnosticSettingsFile}")
-settingsKrb5.graphs.graph = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsKrb5.graphs.classic = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsKrb5.graphs.modern = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsKrb5.graphs.crew = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsKrb5.graphs.grateful = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsKrb5.graphs.sink = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsKrb5.scriptEngines["gremlin-groovy"].plugins["org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin"].files = [platformAgnosticGremlinServerDir + "/src/test/scripts/generate-all.groovy"]
+def settingsKrb5 = Settings.read("${settingsFile}")
+settingsKrb5.graphs.graph = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsKrb5.graphs.classic = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsKrb5.graphs.modern = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsKrb5.graphs.crew = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsKrb5.graphs.grateful = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsKrb5.graphs.sink = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsKrb5.scriptEngines["gremlin-groovy"].plugins["org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin"].files = [gremlinServerDir + "/src/test/scripts/generate-all.groovy"]
 settingsKrb5.port = 45942
 settingsKrb5.authentication.authenticator = "org.apache.tinkerpop.gremlin.server.auth.Krb5Authenticator"
 settingsKrb5.authentication.config = [

--- a/gremlin-server/src/test/scripts/test-server-start.groovy
+++ b/gremlin-server/src/test/scripts/test-server-start.groovy
@@ -50,8 +50,8 @@ log.info("Transactions validated (enabled with -DincludeNeo4j and only available
 
 def platformAgnosticBaseDirPath = new File(".this-definitely-does-not-exist").absolutePath
         .replace("\\.this-definitely-does-not-exist", "") // Windows
+        .replace("\\", "/") // Windows
         .replace("/.this-definitely-does-not-exist","") // Unix
-        .replace("\\", "/")
 def platformAgnosticGremlinServerDir = platformAgnosticBaseDirPath + "/gremlin-server"
 def platformAgnosticSettingsFile = platformAgnosticGremlinServerDir + "/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml"
 
@@ -71,7 +71,6 @@ server.start().join()
 
 project.setContextValue("gremlin.server", server)
 log.info("Gremlin Server without authentication started on port 45940")
-log.info("${platformAgnosticBaseDirPath}")
 
 
 def securePropsFile = new File("${platformAgnosticBaseDirPath}/target/tinkergraph-credentials.properties")
@@ -94,7 +93,6 @@ settingsSecure.scriptEngines["gremlin-groovy"].plugins["org.apache.tinkerpop.gre
 settingsSecure.port = 45941
 settingsSecure.authentication.authenticator = "org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator"
 settingsSecure.authentication.config = [credentialsDb: platformAgnosticBaseDirPath + "/target/tinkergraph-credentials.properties"]
-log.warn(settingsSecure.authentication.config.get("credentialsDb") + "lmaooo")
 settingsSecure.ssl = new Settings.SslSettings()
 settingsSecure.ssl.enabled = true
 settingsSecure.ssl.sslEnabledProtocols = ["TLSv1.2"]

--- a/gremlin-server/src/test/scripts/test-server-start.groovy
+++ b/gremlin-server/src/test/scripts/test-server-start.groovy
@@ -62,12 +62,16 @@ settings.port = 45940
 def server = new GremlinServer(settings)
 server.start().join()
 
+def platformAgnosticBaseDirPath = new File(".this-definitely-does-not-exist").absolutePath
+        .replace("\\.this-definitely-does-not-exist", "") // Windows
+        .replace("tinkerpop/.this-definitely-does-not-exist","") // Unix
+
 project.setContextValue("gremlin.server", server)
 log.info("Gremlin Server without authentication started on port 45940")
-log.info("${projectBaseDir}")
+log.info("${platformAgnosticBaseDirPath}")
 
 
-def securePropsFile = new File("${projectBaseDir}/target/tinkergraph-credentials.properties")
+def securePropsFile = new File("${platformAgnosticBaseDirPath}/target/tinkergraph-credentials.properties")
 if (!securePropsFile.exists()) {
     securePropsFile.createNewFile()
     securePropsFile << "gremlin.graph=org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph\n"
@@ -77,7 +81,6 @@ if (!securePropsFile.exists()) {
 }
 
 def settingsSecure = Settings.read("${settingsFile}")
-def platformAgnosticBaseDirPath = new File(".this-definitely-does-not-exist").absolutePath.replace("\\.this-definitely-does-not-exist", "").replace("tinkerpop/.this-definitely-does-not-exist","")
 settingsSecure.graphs.graph = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
 settingsSecure.graphs.classic = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
 settingsSecure.graphs.modern = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
@@ -101,11 +104,11 @@ project.setContextValue("gremlin.server.secure", serverSecure)
 log.info("Gremlin Server with password authentication started on port 45941")
 
 
-def kdcServer = new KdcFixture(projectBaseDir)
+def kdcServer = new KdcFixture(platformAgnosticBaseDirPath)
 kdcServer.setUp()
 
 project.setContextValue("gremlin.server.kdcserver", kdcServer)
-log.info("KDC started with configuration ${projectBaseDir}/target/kdc/krb5.conf")
+log.info("KDC started with configuration ${platformAgnosticBaseDirPath}/target/kdc/krb5.conf")
 
 def settingsKrb5 = Settings.read("${settingsFile}")
 settingsKrb5.graphs.graph = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"

--- a/gremlin-server/src/test/scripts/test-server-start.groovy
+++ b/gremlin-server/src/test/scripts/test-server-start.groovy
@@ -64,9 +64,10 @@ server.start().join()
 
 project.setContextValue("gremlin.server", server)
 log.info("Gremlin Server without authentication started on port 45940")
+log.info("${projectBaseDir}")
 
 
-def securePropsFile = new File("${projectBaseDir}${projectBaseDir}/target/tinkergraph-credentials.properties")
+def securePropsFile = new File("${projectBaseDir}/target/tinkergraph-credentials.properties")
 if (!securePropsFile.exists()) {
     securePropsFile.createNewFile()
     securePropsFile << "gremlin.graph=org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph\n"

--- a/gremlin-server/src/test/scripts/test-server-start.groovy
+++ b/gremlin-server/src/test/scripts/test-server-start.groovy
@@ -51,6 +51,7 @@ log.info("Transactions validated (enabled with -DincludeNeo4j and only available
 def platformAgnosticBaseDirPath = new File(".this-definitely-does-not-exist").absolutePath
         .replace("\\.this-definitely-does-not-exist", "") // Windows
         .replace("/.this-definitely-does-not-exist","") // Unix
+        .replace("\\", "/")
 def platformAgnosticGremlinServerDir = platformAgnosticBaseDirPath + "/gremlin-server"
 def platformAgnosticSettingsFile = platformAgnosticGremlinServerDir + "/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml"
 

--- a/gremlint/pom.xml
+++ b/gremlint/pom.xml
@@ -72,7 +72,8 @@ limitations under the License.
                                 <script>
                                     def mavenVersion = "${project.version}"
                                     def versionForJs = mavenVersion.replace("-SNAPSHOT", "-alpha1")
-                                    def file = new File("${project.basedir}/package.json")
+                                    def path = new File(".").absolutePath.replace("\\.", "")
+                                    def file = new File(path + "/gremlint/package.json")
                                     file.write(file.getText("UTF-8").replaceFirst(/"version": "(.*)",/, "\"version\": \"" + versionForJs + "\","))
                                 </script>
                             </scripts>

--- a/gremlint/pom.xml
+++ b/gremlint/pom.xml
@@ -72,8 +72,7 @@ limitations under the License.
                                 <script>
                                     def mavenVersion = "${project.version}"
                                     def versionForJs = mavenVersion.replace("-SNAPSHOT", "-alpha1")
-                                    def path = new File(".").absolutePath.replace("\\.", "")
-                                    def file = new File(path + "/gremlint/package.json")
+                                    def file = new File("${project.basedir}/package.json")
                                     file.write(file.getText("UTF-8").replaceFirst(/"version": "(.*)",/, "\"version\": \"" + versionForJs + "\","))
                                 </script>
                             </scripts>

--- a/gremlint/pom.xml
+++ b/gremlint/pom.xml
@@ -72,8 +72,8 @@ limitations under the License.
                                 <script>
                                     def mavenVersion = "${project.version}"
                                     def versionForJs = mavenVersion.replace("-SNAPSHOT", "-alpha1")
-                                    def path = new File(".this-definitely-does-not-exist").absolutePath.replace("\\.this-definitely-does-not-exist", "").replace("\\","/")
-                                    def file = new File(path + "/gremlint/package.json")
+                                    def platformAgnosticBaseDirPath = new File(".this-definitely-does-not-exist").absolutePath.replace("\\.this-definitely-does-not-exist", "").replace("/.this-definitely-does-not-exist", "").replace("\\","/")
+                                    def file = new File(platformAgnosticBaseDirPath + "/gremlint/package.json")
                                     file.write(file.getText("UTF-8").replaceFirst(/"version": "(.*)",/, "\"version\": \"" + versionForJs + "\","))
                                 </script>
                             </scripts>

--- a/gremlint/pom.xml
+++ b/gremlint/pom.xml
@@ -72,7 +72,7 @@ limitations under the License.
                                 <script>
                                     def mavenVersion = "${project.version}"
                                     def versionForJs = mavenVersion.replace("-SNAPSHOT", "-alpha1")
-                                    def path = new File(".").absolutePath.replace("\\.", "").replace("\\","/")
+                                    def path = new File(".this-definitely-does-not-exist").absolutePath.replace("\\.this-definitely-does-not-exist", "").replace("\\","/")
                                     def file = new File(path + "/gremlint/package.json")
                                     file.write(file.getText("UTF-8").replaceFirst(/"version": "(.*)",/, "\"version\": \"" + versionForJs + "\","))
                                 </script>

--- a/gremlint/pom.xml
+++ b/gremlint/pom.xml
@@ -72,7 +72,7 @@ limitations under the License.
                                 <script>
                                     def mavenVersion = "${project.version}"
                                     def versionForJs = mavenVersion.replace("-SNAPSHOT", "-alpha1")
-                                    def path = new File(".").absolutePath.replace("\\.", "")
+                                    def path = new File(".").absolutePath.replace("\\.", "").replace("\\","/")
                                     def file = new File(path + "/gremlint/package.json")
                                     file.write(file.getText("UTF-8").replaceFirst(/"version": "(.*)",/, "\"version\": \"" + versionForJs + "\","))
                                 </script>


### PR DESCRIPTION
*Issue #, if available:*
https://bitquill.atlassian.net/browse/AN-1146

*Description of changes:*
Fixed issues where running `mvn clean install` on Windows causes:
1.
```
error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
error  Delete `␍`                                       prettier/prettier
```
2.
```
Script1.groovy: 3: unexpected char: '\' @ line 3, column 24.
```
3.
```
> gremlin@3.5.4-alpha1 test
> ./node_modules/mocha/bin/mocha test/unit test/integration -t 5000

'.' is not recognized as an internal or external command,
operable program or batch file.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
