### PR TITLE
Made GraphBinary the default serialization format for .NET and Python

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
@@ -26,6 +26,7 @@ using System.Net.WebSockets;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver.Messages;
 using Gremlin.Net.Structure.IO;
+using Gremlin.Net.Structure.IO.GraphBinary;
 using Gremlin.Net.Structure.IO.GraphSON;
 
 namespace Gremlin.Net.Driver
@@ -159,7 +160,7 @@ namespace Gremlin.Net.Driver
             Action<ClientWebSocketOptions> webSocketConfiguration = null, string sessionId = null,
             bool disableCompression = false)
         {
-            messageSerializer ??= new GraphSON3MessageSerializer();
+            messageSerializer ??= new GraphBinaryMessageSerializer();
             var webSocketSettings = new WebSocketSettings
             {
                 WebSocketConfigurationCallback = webSocketConfiguration

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/GremlinClientTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/GremlinClientTests.cs
@@ -23,8 +23,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.WebSockets;
-using System.Text.Json;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver;
 using Gremlin.Net.Driver.Exceptions;
@@ -179,8 +179,7 @@ namespace Gremlin.Net.IntegrationTest.Driver
 
             Assert.NotNull(resultSet.StatusAttributes);
 
-            var values = (JsonElement) resultSet.StatusAttributes["@value"];
-            Assert.True(values[0].ToString().Equals("host"));
+            Assert.True(resultSet.StatusAttributes.First().Key == "host");
         }
 
         [Fact]

--- a/gremlin-python/src/main/python/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/client.py
@@ -50,7 +50,7 @@ class Client:
         if "max_content_length" not in transport_kwargs:
             transport_kwargs["max_content_length"] = 10 * 1024 * 1024
         if message_serializer is None:
-            message_serializer = serializer.GraphSONSerializersV3d0()
+            message_serializer = serializer.GraphBinarySerializersV1()
         self._message_serializer = message_serializer
         self._username = username
         self._password = password

--- a/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
@@ -59,10 +59,12 @@ class DriverRemoteConnection(RemoteConnection):
         # so that they can be closed if this parent session is closed.
         self.__spawned_sessions = []
 
-        if message_serializer is None:
+        if message_serializer is None and (graphson_reader is not None or graphson_writer is not None):
             message_serializer = serializer.GraphSONMessageSerializer(
                 reader=graphson_reader,
                 writer=graphson_writer)
+        else:
+            message_serializer = serializer.graphbinaryV1()
         self._client = client.Client(url, traversal_source,
                                      protocol_factory=protocol_factory,
                                      transport_factory=transport_factory,

--- a/gremlin-python/src/main/python/gremlin_python/driver/serializer.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/serializer.py
@@ -97,9 +97,9 @@ class GraphSONMessageSerializer(object):
     """
 
     # KEEP TRACK OF CURRENT DEFAULTS
-    DEFAULT_READER_CLASS = graphsonV3d0.GraphSONReader
-    DEFAULT_WRITER_CLASS = graphsonV3d0.GraphSONWriter
-    DEFAULT_VERSION = b"application/vnd.gremlin-v3.0+json"
+    DEFAULT_READER_CLASS = graphbinaryV1.GraphBinaryReader
+    DEFAULT_WRITER_CLASS = graphbinaryV1.GraphBinaryWriter
+    DEFAULT_VERSION = b"application/vnd.graphbinary-v1.0"
 
     def __init__(self, reader=None, writer=None, version=None):
         if not version:


### PR DESCRIPTION
*Issue #, if available:*
https://bitquill.atlassian.net/browse/AN-1163

*Description of changes:*
Make GraphBinary the default serialization format for .NET and Python

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
