### PR TITLE
Make GraphBinary the default serialization format for .NET

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
@@ -26,6 +26,7 @@ using System.Net.WebSockets;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver.Messages;
 using Gremlin.Net.Structure.IO;
+using Gremlin.Net.Structure.IO.GraphBinary;
 using Gremlin.Net.Structure.IO.GraphSON;
 
 namespace Gremlin.Net.Driver
@@ -159,7 +160,7 @@ namespace Gremlin.Net.Driver
             Action<ClientWebSocketOptions> webSocketConfiguration = null, string sessionId = null,
             bool disableCompression = false)
         {
-            messageSerializer ??= new GraphSON3MessageSerializer();
+            messageSerializer ??= new GraphBinaryMessageSerializer();
             var webSocketSettings = new WebSocketSettings
             {
                 WebSocketConfigurationCallback = webSocketConfiguration

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/GremlinClientTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/GremlinClientTests.cs
@@ -24,7 +24,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net.WebSockets;
-using System.Text.Json;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver;
 using Gremlin.Net.Driver.Exceptions;
@@ -178,9 +177,7 @@ namespace Gremlin.Net.IntegrationTest.Driver
             var resultSet = await gremlinClient.SubmitAsync<int>(requestMsg);
 
             Assert.NotNull(resultSet.StatusAttributes);
-
-            var values = (JsonElement) resultSet.StatusAttributes["@value"];
-            Assert.True(values[0].ToString().Equals("host"));
+            Assert.True(resultSet.StatusAttributes.ContainsKey("host"));
         }
 
         [Fact]


### PR DESCRIPTION
*Issue #, if available:*
https://bitquill.atlassian.net/browse/AN-1163

*Description of changes:*
[TINKERPOP-2723] Make GraphBinary the default serialization format for .NET

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
