### PR TITLE
set graphbinary as default; fix tests

### DIFF
--- a/gremlin-python/src/main/python/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/client.py
@@ -52,7 +52,9 @@ class Client:
         if "max_content_length" not in transport_kwargs:
             transport_kwargs["max_content_length"] = 10 * 1024 * 1024
         if message_serializer is None:
-            message_serializer = serializer.GraphSONSerializersV3d0()
+            message_serializer = serializer.GraphBinarySerializersV1()
+            # message_serializer = serializer.GraphSONSerializersV3d0()
+
         self._message_serializer = message_serializer
         self._username = username
         self._password = password

--- a/gremlin-python/src/main/python/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/client.py
@@ -52,7 +52,7 @@ class Client:
         if "max_content_length" not in transport_kwargs:
             transport_kwargs["max_content_length"] = 10 * 1024 * 1024
         if message_serializer is None:
-            message_serializer = serializer.GraphBinarySerializersV1()
+            message_serializer = serializer.GraphSONSerializersV3d0()
 
         self._message_serializer = message_serializer
         self._username = username

--- a/gremlin-python/src/main/python/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/client.py
@@ -53,7 +53,6 @@ class Client:
             transport_kwargs["max_content_length"] = 10 * 1024 * 1024
         if message_serializer is None:
             message_serializer = serializer.GraphBinarySerializersV1()
-            # message_serializer = serializer.GraphSONSerializersV3d0()
 
         self._message_serializer = message_serializer
         self._username = username

--- a/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
@@ -61,7 +61,7 @@ class DriverRemoteConnection(RemoteConnection):
         # so that they can be closed if this parent session is closed.
         self.__spawned_sessions = []
 
-        if message_serializer is None and graphson_reader is None and graphson_writer is None:
+        if message_serializer is None and graphson_reader is not None and graphson_writer is not None:
             message_serializer = serializer.GraphSONMessageSerializer(
                 reader=graphson_reader,
                 writer=graphson_writer)

--- a/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
@@ -61,7 +61,7 @@ class DriverRemoteConnection(RemoteConnection):
         # so that they can be closed if this parent session is closed.
         self.__spawned_sessions = []
 
-        if message_serializer is None:
+        if message_serializer is None and graphson_reader is None and graphson_writer is None:
             message_serializer = serializer.GraphSONMessageSerializer(
                 reader=graphson_reader,
                 writer=graphson_writer)

--- a/gremlin-python/src/main/python/gremlin_python/driver/serializer.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/serializer.py
@@ -24,7 +24,6 @@ import struct
 import uuid
 import io
 
-from gremlin_python.process import traversal
 from gremlin_python.structure.io import graphbinaryV1
 from gremlin_python.structure.io import graphsonV2d0
 from gremlin_python.structure.io import graphsonV3d0

--- a/gremlin-python/src/main/python/gremlin_python/driver/serializer.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/serializer.py
@@ -24,6 +24,7 @@ import struct
 import uuid
 import io
 
+from gremlin_python.process import traversal
 from gremlin_python.structure.io import graphbinaryV1
 from gremlin_python.structure.io import graphsonV2d0
 from gremlin_python.structure.io import graphsonV3d0
@@ -256,7 +257,8 @@ class GraphBinarySerializersV1(object):
             # just works but python 2 bytearray is bound to ByteBufferType so it writes DataType.bytebuffer
             # rather than DataType.bytecode and the server gets confused. special casing this for now until
             # it can be refactored
-            if k == "gremlin":
+            # todo: WTF??? handle byte array/buffer
+            if k == "gremlin" and isinstance(v, bytearray):
                 ba.extend(v)
             else:
                 self._graphbinary_writer.to_dict(v, ba)

--- a/gremlin-python/src/main/python/gremlin_python/driver/serializer.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/serializer.py
@@ -257,7 +257,6 @@ class GraphBinarySerializersV1(object):
             # just works but python 2 bytearray is bound to ByteBufferType so it writes DataType.bytebuffer
             # rather than DataType.bytecode and the server gets confused. special casing this for now until
             # it can be refactored
-            # todo: WTF??? handle byte array/buffer
             if k == "gremlin" and isinstance(v, bytearray):
                 ba.extend(v)
             else:

--- a/gremlin-python/src/main/python/gremlin_python/statics.py
+++ b/gremlin-python/src/main/python/gremlin_python/statics.py
@@ -81,7 +81,13 @@ class GremlinType(object):
     """
     def __init__(self, gremlin_type):
         self.gremlin_type = gremlin_type
-        
+
+
+class BigDecimal(object):
+    def __init__(self, scale, unscaled_value):
+        self.scale = scale
+        self.unscaled_value = unscaled_value
+
 
 staticMethods = {}
 staticEnums = {}

--- a/gremlin-python/src/main/python/gremlin_python/statics.py
+++ b/gremlin-python/src/main/python/gremlin_python/statics.py
@@ -29,7 +29,12 @@ class bigint(int):
     pass
 
 
+class short(int):
+    pass
+
+
 FloatType = float
+ShortType = short
 IntType = int
 LongType = long
 BigIntType = bigint

--- a/gremlin-python/src/main/python/gremlin_python/statics.py
+++ b/gremlin-python/src/main/python/gremlin_python/statics.py
@@ -25,9 +25,14 @@ class long(int):
     pass
 
 
+class bigint(int):
+    pass
+
+
 FloatType = float
 IntType = int
 LongType = long
+BigIntType = bigint
 TypeType = type
 ListType = list
 DictType = dict

--- a/gremlin-python/src/main/python/gremlin_python/structure/io/graphbinaryV1.py
+++ b/gremlin-python/src/main/python/gremlin_python/structure/io/graphbinaryV1.py
@@ -247,6 +247,10 @@ class LongIO(_GraphBinaryTypeIO):
         if obj < -9223372036854775808 or obj > 9223372036854775807:
             raise Exception("TODO: don't forget bigint")
         else:
+            if obj < -2147483648 or obj > 2147483647:
+                cls.graphbinary_type = DataType.long
+                cls.byte_format_pack = int64_pack
+                cls.byte_format_unpack = int64_unpack
             cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
             to_extend.extend(cls.byte_format_pack(obj))
             return to_extend

--- a/gremlin-python/src/main/python/gremlin_python/structure/io/graphbinaryV1.py
+++ b/gremlin-python/src/main/python/gremlin_python/structure/io/graphbinaryV1.py
@@ -280,22 +280,22 @@ class BigIntIO(_GraphBinaryTypeIO):
     def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
         cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
         length = (obj.bit_length() + 7) // 8
-        b = obj.to_bytes(length, byteorder='big')
         if obj > 0:
+            b = obj.to_bytes(length, byteorder='big')
             to_extend.extend(int32_pack(length + 1))
             to_extend.extend(int8_pack(0))
             to_extend.extend(b)
         else:
             # handle negative
+            b = obj.to_bytes(length, byteorder='big', signed=True)
             to_extend.extend(int32_pack(length))
             to_extend.extend(b)
         return to_extend
 
-    # todo: copy from str code
     @classmethod
     def _read_arr(cls, buff):
         size = cls.read_int(buff)
-        return int.from_bytes(buff.read(size), byteorder='big')
+        return int.from_bytes(buff.read(size), byteorder='big', signed=True)
 
     @classmethod
     def objectify(cls, buff, reader, nullable=False):

--- a/gremlin-python/src/main/python/gremlin_python/structure/io/graphbinaryV1.py
+++ b/gremlin-python/src/main/python/gremlin_python/structure/io/graphbinaryV1.py
@@ -48,6 +48,7 @@ log = logging.getLogger(__name__)
 _serializers = OrderedDict()
 _deserializers = {}
 
+
 class DataType(Enum):
     null = 0xfe
     int = 0x01

--- a/gremlin-python/src/main/python/tests/driver/test_client.py
+++ b/gremlin-python/src/main/python/tests/driver/test_client.py
@@ -27,7 +27,7 @@ from gremlin_python.process.graph_traversal import __
 from gremlin_python.process.strategies import OptionsStrategy
 from gremlin_python.structure.graph import Graph
 from gremlin_python.driver.aiohttp.transport import AiohttpTransport
-from gremlin_python.statics import bigint
+from gremlin_python.statics import *
 from asyncio import TimeoutError
 
 __author__ = 'David M. Brown (davebshow@gmail.com)'
@@ -243,7 +243,7 @@ def test_multi_thread_pool(client):
 
 def test_client_bytecode_with_long(client):
     g = Graph().traversal()
-    t = g.V().has('age', 851401972585122).count()
+    t = g.V().has('age', long(851401972585122)).count()
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
     result_set = client.submit(message)
     results = []

--- a/gremlin-python/src/main/python/tests/driver/test_client.py
+++ b/gremlin-python/src/main/python/tests/driver/test_client.py
@@ -99,7 +99,7 @@ def test_client_side_timeout_set_for_aiohttp(client):
 
     try:
         # should fire an exception
-        client.submit('Thread.sleep(2000);1').all().result()
+        client.submit('Thread.sleep(1000);1').all().result()
         assert False
     except TimeoutError as err:
         # asyncio TimeoutError has no message.

--- a/gremlin-python/src/main/python/tests/driver/test_client.py
+++ b/gremlin-python/src/main/python/tests/driver/test_client.py
@@ -32,6 +32,8 @@ from asyncio import TimeoutError
 
 __author__ = 'David M. Brown (davebshow@gmail.com)'
 
+test_no_auth_url = 'ws://localhost:45940/gremlin'
+
 
 def test_connection(connection):
     g = Graph().traversal()
@@ -48,7 +50,7 @@ def test_connection(connection):
 
 def test_client_message_too_big(client):
     try:
-        client = Client('ws://localhost:45940/gremlin', 'g', max_content_length=1024)
+        client = Client(test_no_auth_url, 'g', max_content_length=1024)
         client.submit("\" \".repeat(2000)").all().result()
         assert False
     except Exception as ex:
@@ -82,7 +84,7 @@ def test_client_error(client):
 
 def test_client_connection_pool_after_error(client):
     # Overwrite fixture with pool_size=1 client
-    client = Client('ws://localhost:45940/gremlin', 'gmodern', pool_size=1)
+    client = Client(test_no_auth_url, 'gmodern', pool_size=1)
 
     try:
         # should fire an exception
@@ -95,7 +97,7 @@ def test_client_connection_pool_after_error(client):
 
 
 def test_client_side_timeout_set_for_aiohttp(client):
-    client = Client('ws://localhost:45940/gremlin', 'gmodern',
+    client = Client(test_no_auth_url, 'gmodern',
                     transport_factory=lambda: AiohttpTransport(read_timeout=1, write_timeout=1))
 
     try:
@@ -110,7 +112,7 @@ def test_client_side_timeout_set_for_aiohttp(client):
 async def async_connect(enable):
     try:
         transport = AiohttpTransport(call_from_event_loop=enable)
-        transport.connect('ws://localhost:45940/gremlin')
+        transport.connect(test_no_auth_url)
         transport.close()
         return True
     except RuntimeError:
@@ -167,7 +169,7 @@ def test_client_async(client):
 
 def test_connection_share(client):
     # Overwrite fixture with pool_size=1 client
-    client = Client('ws://localhost:45940/gremlin', 'gmodern', pool_size=1)
+    client = Client(test_no_auth_url, 'gmodern', pool_size=1)
     g = Graph().traversal()
     t = g.V()
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
@@ -189,7 +191,7 @@ def test_multi_conn_pool(client):
     t = g.V()
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
     message2 = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
-    client = Client('ws://localhost:45940/gremlin', 'g', pool_size=1)
+    client = Client(test_no_auth_url, 'g', pool_size=1)
     future = client.submit_async(message)
     future2 = client.submit_async(message2)
 
@@ -267,7 +269,7 @@ def test_client_bytecode_with_bigint(client):
 def test_multi_request_in_session(client):
     # Overwrite fixture with session client
     session_id = str(uuid.uuid4())
-    client = Client('ws://localhost:45940/gremlin', 'g', session=session_id)
+    client = Client(test_no_auth_url, 'g', session=session_id)
 
     assert client.submit('x = 1').all().result()[0] == 1
     assert client.submit('x + 2').all().result()[0] == 3
@@ -275,7 +277,7 @@ def test_multi_request_in_session(client):
     client.close()
 
     # attempt reconnect to session and make sure "x" is no longer a thing
-    client = Client('ws://localhost:45940/gremlin', 'g', session=session_id)
+    client = Client(test_no_auth_url, 'g', session=session_id)
     try:
         # should fire an exception
         client.submit('x').all().result()
@@ -288,7 +290,7 @@ def test_client_pool_in_session(client):
     # Overwrite fixture with pool_size=2 client
     try:
         # should fire an exception
-        client = Client('ws://localhost:45940/gremlin', 'g', session=str(uuid.uuid4()), pool_size=2)
+        client = Client(test_no_auth_url, 'g', session=str(uuid.uuid4()), pool_size=2)
         assert False
     except Exception:
         assert True

--- a/gremlin-python/src/main/python/tests/driver/test_client.py
+++ b/gremlin-python/src/main/python/tests/driver/test_client.py
@@ -240,9 +240,20 @@ def test_multi_thread_pool(client):
     assert results[3][0][0].object == 6
 
 
-def test_client_bytecode_with_int(client):
+def test_client_bytecode_with_long(client):
     g = Graph().traversal()
     t = g.V().has('age', 851401972585122).count()
+    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
+    result_set = client.submit(message)
+    results = []
+    for result in result_set:
+        results += result
+    assert len(results) == 1
+
+
+def test_client_bytecode_with_bigint(client):
+    g = Graph().traversal()
+    t = g.V().has('age', 0x1000_0000_0000_0000_0000).count()
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
     result_set = client.submit(message)
     results = []

--- a/gremlin-python/src/main/python/tests/driver/test_client.py
+++ b/gremlin-python/src/main/python/tests/driver/test_client.py
@@ -52,7 +52,8 @@ def test_client_message_too_big(client):
         client.submit("\" \".repeat(2000)").all().result()
         assert False
     except Exception as ex:
-        assert ex.args[0] == "Received error on read: 'Message size 2080 exceeds limit 1024'"
+        assert ex.args[0].startswith("Received error on read: 'Message size") \
+               and ex.args[0].endswith("exceeds limit 1024'")
     finally:
         client.close()
 

--- a/gremlin-python/src/main/python/tests/driver/test_client.py
+++ b/gremlin-python/src/main/python/tests/driver/test_client.py
@@ -47,11 +47,11 @@ def test_connection(connection):
 
 def test_client_message_too_big(client):
     try:
-        client = Client("http://localhost", 'g', max_content_length=1024)
-        client.submit("1+1").all().result()
+        client = Client('ws://localhost:45940/gremlin', 'g', max_content_length=1024)
+        client.submit("\" \".repeat(2000)").all().result()
         assert False
-    except Exception:
-        assert True
+    except Exception as ex:
+        assert ex.args[0] == "Received error on read: 'Message size 2080 exceeds limit 1024'"
     finally:
         client.close()
 

--- a/gremlin-python/src/main/python/tests/driver/test_client.py
+++ b/gremlin-python/src/main/python/tests/driver/test_client.py
@@ -27,6 +27,7 @@ from gremlin_python.process.graph_traversal import __
 from gremlin_python.process.strategies import OptionsStrategy
 from gremlin_python.structure.graph import Graph
 from gremlin_python.driver.aiohttp.transport import AiohttpTransport
+from gremlin_python.statics import bigint
 from asyncio import TimeoutError
 
 __author__ = 'David M. Brown (davebshow@gmail.com)'
@@ -253,7 +254,7 @@ def test_client_bytecode_with_long(client):
 
 def test_client_bytecode_with_bigint(client):
     g = Graph().traversal()
-    t = g.V().has('age', 0x1000_0000_0000_0000_0000).count()
+    t = g.V().has('age', bigint(0x1000_0000_0000_0000_0000)).count()
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
     result_set = client.submit(message)
     results = []

--- a/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
@@ -209,7 +209,7 @@ class TestDriverRemoteConnection(object):
         #
         g = traversal().withRemote(remote_connection).with_("x", True).with_('evaluationTimeout', 10)
         try:
-            g.inject(1).sideEffect(lambda: ("Thread.sleep(5000)", "gremlin-groovy")).iterate()
+            g.inject(1).sideEffect(lambda: ("Thread.sleep(1000)", "gremlin-groovy")).iterate()
             assert False
         except GremlinServerError as gse:
             assert gse.status_code == 598

--- a/gremlin-python/src/main/python/tests/structure/io/test_functionalityio.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_functionalityio.py
@@ -65,6 +65,22 @@ def test_uuid(remote_connection):
         g.V(vid).drop().iterate()
 
 
+def test_short(remote_connection):
+    if not isinstance(remote_connection._client._message_serializer, GraphBinarySerializersV1):
+        return
+
+    g = Graph().traversal().withRemote(remote_connection)
+    num = short(1111)
+    resp = g.addV('test_vertex').property('short', num).toList()
+    vid = resp[0].id
+    try:
+        bigint_prop = g.V(vid).properties('short').toList()[0]
+        assert isinstance(bigint_prop.value, int)
+        assert bigint_prop.value == num
+    finally:
+        g.V(vid).drop().iterate()
+
+
 def test_bigint_positive(remote_connection):
     if not isinstance(remote_connection._client._message_serializer, GraphBinarySerializersV1):
         return

--- a/gremlin-python/src/main/python/tests/structure/io/test_functionalityio.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_functionalityio.py
@@ -65,6 +65,19 @@ def test_uuid(remote_connection):
         g.V(vid).drop().iterate()
 
 
+def test_bigint(remote_connection):
+    g = Graph().traversal().withRemote(remote_connection)
+    big = bigint(0x1000_0000_0000_0000_0000)
+    resp = g.addV('test_vertex').property('bigint', big).toList()
+    vid = resp[0].id
+    try:
+        bigint_prop = g.V(vid).properties('bigint').toList()[0]
+        assert isinstance(bigint_prop.value, int)
+        assert bigint_prop.value == big
+    finally:
+        g.V(vid).drop().iterate()
+
+
 def test_odd_bits(remote_connection):
     if not isinstance(remote_connection._client._message_serializer, GraphSONSerializersV2d0):
         g = Graph().traversal().withRemote(remote_connection)
@@ -85,7 +98,7 @@ def test_odd_bits(remote_connection):
             assert v == char_upper
         finally:
             g.V(vid).drop().iterate()
-                
+
         dur = datetime.timedelta(seconds=1000, microseconds=1000)
         resp = g.addV('test_vertex').property('dur', dur).toList()
         vid = resp[0].id

--- a/gremlin-python/src/main/python/tests/structure/io/test_functionalityio.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_functionalityio.py
@@ -113,6 +113,23 @@ def test_bigint_negative(remote_connection):
         g.V(vid).drop().iterate()
 
 
+def test_bigdecimal(remote_connection):
+    if not isinstance(remote_connection._client._message_serializer, GraphBinarySerializersV1):
+        return
+
+    g = Graph().traversal().withRemote(remote_connection)
+    bigdecimal = BigDecimal(101, 235)
+    resp = g.addV('test_vertex').property('bigdecimal', bigdecimal).toList()
+    vid = resp[0].id
+    try:
+        bigdecimal_prop = g.V(vid).properties('bigdecimal').toList()[0]
+        assert isinstance(bigdecimal_prop.value, BigDecimal)
+        assert bigdecimal_prop.value.scale == bigdecimal.scale
+        assert bigdecimal_prop.value.unscaled_value == bigdecimal.unscaled_value
+    finally:
+        g.V(vid).drop().iterate()
+
+
 def test_odd_bits(remote_connection):
     if not isinstance(remote_connection._client._message_serializer, GraphSONSerializersV2d0):
         g = Graph().traversal().withRemote(remote_connection)

--- a/gremlin-python/src/main/python/tests/structure/io/test_functionalityio.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_functionalityio.py
@@ -65,12 +65,28 @@ def test_uuid(remote_connection):
         g.V(vid).drop().iterate()
 
 
-def test_bigint(remote_connection):
+def test_bigint_positive(remote_connection):
     if not isinstance(remote_connection._client._message_serializer, GraphBinarySerializersV1):
         return
 
     g = Graph().traversal().withRemote(remote_connection)
     big = bigint(0x1000_0000_0000_0000_0000)
+    resp = g.addV('test_vertex').property('bigint', big).toList()
+    vid = resp[0].id
+    try:
+        bigint_prop = g.V(vid).properties('bigint').toList()[0]
+        assert isinstance(bigint_prop.value, int)
+        assert bigint_prop.value == big
+    finally:
+        g.V(vid).drop().iterate()
+
+
+def test_bigint_negative(remote_connection):
+    if not isinstance(remote_connection._client._message_serializer, GraphBinarySerializersV1):
+        return
+
+    g = Graph().traversal().withRemote(remote_connection)
+    big = bigint(-0x1000_0000_0000_0000_0000)
     resp = g.addV('test_vertex').property('bigint', big).toList()
     vid = resp[0].id
     try:

--- a/gremlin-python/src/main/python/tests/structure/io/test_functionalityio.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_functionalityio.py
@@ -20,7 +20,7 @@ under the License.
 import datetime
 import uuid
 
-from gremlin_python.driver.serializer import GraphSONSerializersV2d0
+from gremlin_python.driver.serializer import GraphSONSerializersV2d0, GraphBinarySerializersV1
 from gremlin_python.structure.graph import Graph
 from gremlin_python.statics import *
 
@@ -66,6 +66,9 @@ def test_uuid(remote_connection):
 
 
 def test_bigint(remote_connection):
+    if not isinstance(remote_connection._client._message_serializer, GraphBinarySerializersV1):
+        return
+
     g = Graph().traversal().withRemote(remote_connection)
     big = bigint(0x1000_0000_0000_0000_0000)
     resp = g.addV('test_vertex').property('bigint', big).toList()

--- a/gremlin-python/src/main/python/tests/structure/io/test_graphbinaryV1.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_graphbinaryV1.py
@@ -21,7 +21,7 @@ import datetime
 import uuid
 import math
 
-from gremlin_python.statics import timestamp, long, bigint, SingleByte, SingleChar, ByteBufferType
+from gremlin_python.statics import timestamp, long, bigint, BigDecimal, SingleByte, SingleChar, ByteBufferType
 from gremlin_python.structure.graph import Vertex, Edge, Property, VertexProperty, Path
 from gremlin_python.structure.io.graphbinaryV1 import GraphBinaryWriter, GraphBinaryReader
 from gremlin_python.process.traversal import Barrier, Binding, Bytecode, Merge, Direction
@@ -77,6 +77,12 @@ class TestGraphSONWriter(object):
         x = 100.001
         output = self.graphbinary_reader.read_object(self.graphbinary_writer.write_object(x))
         assert x == output
+
+    def test_bigdecimal(self):
+        x = BigDecimal(100, 234)
+        output = self.graphbinary_reader.read_object(self.graphbinary_writer.write_object(x))
+        assert x.scale == output.scale
+        assert x.unscaled_value == output.unscaled_value
 
     def test_date(self):
         x = datetime.datetime(2016, 12, 14, 16, 14, 36, 295000)

--- a/gremlin-python/src/main/python/tests/structure/io/test_graphbinaryV1.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_graphbinaryV1.py
@@ -21,7 +21,7 @@ import datetime
 import uuid
 import math
 
-from gremlin_python.statics import timestamp, long, SingleByte, SingleChar, ByteBufferType
+from gremlin_python.statics import timestamp, long, bigint, SingleByte, SingleChar, ByteBufferType
 from gremlin_python.structure.graph import Vertex, Edge, Property, VertexProperty, Path
 from gremlin_python.structure.io.graphbinaryV1 import GraphBinaryWriter, GraphBinaryReader
 from gremlin_python.process.traversal import Barrier, Binding, Bytecode, Merge, Direction
@@ -52,7 +52,7 @@ class TestGraphSONWriter(object):
         assert x == output
 
     def test_bigint(self):
-        x = 0x1000_0000_0000_0000_0000
+        x = bigint(0x1000_0000_0000_0000_0000)
         output = self.graphbinary_reader.read_object(self.graphbinary_writer.write_object(x))
         assert x == output
 

--- a/gremlin-python/src/main/python/tests/structure/io/test_graphbinaryV1.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_graphbinaryV1.py
@@ -51,6 +51,11 @@ class TestGraphSONWriter(object):
         output = self.graphbinary_reader.read_object(self.graphbinary_writer.write_object(x))
         assert x == output
 
+    def test_bigint(self):
+        x = 0x1000_0000_0000_0000_0000
+        output = self.graphbinary_reader.read_object(self.graphbinary_writer.write_object(x))
+        assert x == output
+
     def test_float(self):
         x = float(100.001)
         output = self.graphbinary_reader.read_object(self.graphbinary_writer.write_object(x))


### PR DESCRIPTION
*Issue #, if available:*
https://bitquill.atlassian.net/browse/AN-1165

*Description of changes:*
[TINKERPOP-2693] Finish graphbinary support and enable it by default in gremlin-python

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
