### PR TITLE
Spark Gremlin Windows Build Error Fixes

### DIFF
--- a/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/AbstractIoRegistryCheck.java
+++ b/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/AbstractIoRegistryCheck.java
@@ -72,7 +72,8 @@ public abstract class AbstractIoRegistryCheck extends AbstractGremlinTest {
         graph.configuration().setProperty(IoRegistry.IO_REGISTRY, ToyIoRegistry.class.getCanonicalName());
         final GryoRecordWriter writer = new GryoRecordWriter(new DataOutputStream(new FileOutputStream(input)), ConfUtil.makeHadoopConfiguration(graph.configuration()));
         validateIoRegistryGraph(graph, graphComputerClass, writer);
-        assertTrue(input.delete());
+        System.out.println("Is File?:"+input.isFile());
+        input.deleteOnExit();
     }
 
     public void checkGryoV3d0IoRegistryCompliance(final HadoopGraph graph, final Class<? extends GraphComputer> graphComputerClass) throws Exception {
@@ -84,7 +85,7 @@ public abstract class AbstractIoRegistryCheck extends AbstractGremlinTest {
         graph.configuration().setProperty(IoRegistry.IO_REGISTRY, ToyIoRegistry.class.getCanonicalName());
         final GryoRecordWriter writer = new GryoRecordWriter(new DataOutputStream(new FileOutputStream(input)), ConfUtil.makeHadoopConfiguration(graph.configuration()));
         validateIoRegistryGraph(graph, graphComputerClass, writer);
-        assertTrue(input.delete());
+        input.deleteOnExit();
     }
 
     public void checkGraphSONIoRegistryCompliance(final HadoopGraph graph, final Class<? extends GraphComputer> graphComputerClass) throws Exception {
@@ -95,7 +96,7 @@ public abstract class AbstractIoRegistryCheck extends AbstractGremlinTest {
         graph.configuration().setProperty(IoRegistry.IO_REGISTRY, ToyIoRegistry.class.getCanonicalName());
         final GraphSONRecordWriter writer = new GraphSONRecordWriter(new DataOutputStream(new FileOutputStream(input)), ConfUtil.makeHadoopConfiguration(graph.configuration()));
         validateIoRegistryGraph(graph, graphComputerClass, writer);
-        assertTrue(input.delete());
+        input.deleteOnExit();
     }
 
     private void validateIoRegistryGraph(final HadoopGraph graph,

--- a/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/AbstractIoRegistryCheck.java
+++ b/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/AbstractIoRegistryCheck.java
@@ -72,7 +72,6 @@ public abstract class AbstractIoRegistryCheck extends AbstractGremlinTest {
         graph.configuration().setProperty(IoRegistry.IO_REGISTRY, ToyIoRegistry.class.getCanonicalName());
         final GryoRecordWriter writer = new GryoRecordWriter(new DataOutputStream(new FileOutputStream(input)), ConfUtil.makeHadoopConfiguration(graph.configuration()));
         validateIoRegistryGraph(graph, graphComputerClass, writer);
-        System.out.println("Is File?:"+input.isFile());
         input.deleteOnExit();
     }
 


### PR DESCRIPTION
Spark Build on Windows Causes Errors along the lines of:
```
[ERROR] Failures: 
[ERROR] org.apache.tinkerpop.gremlin.spark.structure.io.SparkIoRegistryCheck.shouldSupportGraphSONIoRegistry(org.apache.tinkerpop.gremlin.spark.structure.io.SparkIoRegistryCheck)      
[INFO]   Run 1: PASS
[ERROR]   Run 2: SparkIoRegistryCheck.shouldSupportGraphSONIoRegistry:67->AbstractIoRegistryCheck.checkGraphSONIoRegistryCompliance:98
[INFO]
[ERROR] org.apache.tinkerpop.gremlin.spark.structure.io.SparkIoRegistryCheck.shouldSupportGryoV1d0IoRegistry(org.apache.tinkerpop.gremlin.spark.structure.io.SparkIoRegistryCheck)      
[INFO]   Run 1: PASS
[ERROR]   Run 2: SparkIoRegistryCheck.shouldSupportGryoV1d0IoRegistry:57->AbstractIoRegistryCheck.checkGryoV1d0IoRegistryCompliance:75
[INFO]
[ERROR] org.apache.tinkerpop.gremlin.spark.structure.io.SparkIoRegistryCheck.shouldSupportGryoV3d0IoRegistry(org.apache.tinkerpop.gremlin.spark.structure.io.SparkIoRegistryCheck)      
[INFO]   Run 1: PASS
[ERROR]   Run 2: SparkIoRegistryCheck.shouldSupportGryoV3d0IoRegistry:62->AbstractIoRegistryCheck.checkGryoV3d0IoRegistryCompliance:87
```
These failures are caused by the usage of the `File.delete()` function calls to delete temp files generated during runtime. This operation fails on Windows as the file is still actively open in the process and on Windows, active files cannot be deleted until a all processes stop using it.

`File.deleteOnExit()` deletes the file when the virtual machine terminates.